### PR TITLE
chore: use Github Apps in release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,19 +8,20 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write
-      contents: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: create-iat
+        with:
+          app-id: ${{ secrets.NPM_RELEASER_GITHUB_APP_ID}}
+          private-key: ${{ secrets.NPM_RELEASER_GITHUB_APP_KEY }}
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.create-iat.outputs.token }}
           manifest-file: .release-please-manifest.json
           config-file: .release-please-config.json
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Currently, release-please is executed with an action token, but this method does not execute other actions when a PR is created.
Therefore, we will change it to use a GitHub Apps token.
## What

<!-- What is a solution you want to add? -->
- use GitHub Apps token in release-please
- remove unused permission in release
## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
