### PR TITLE
chore: update npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [ci-badge]: https://github.com/kintone/mcp-server/actions/workflows/ci.yaml/badge.svg
 [ci-url]: https://github.com/kintone/mcp-server/actions/workflows/ci.yaml
-[npm-badge]: https://badge.fury.io/js/@kintone%2Fmcp-server.svg
+[npm-badge]: https://badge.fury.io/js/@kintone%2Fmcp-server.svg?icon=si%3Anpm
 [npm-url]: https://badge.fury.io/js/@kintone%2Fmcp-server
 [license-badge]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
 [license-url]: LICENSE


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

READMEに置いているnpm version badgeを更新する

https://badge.fury.io/for/js/@kintone/mcp-server?icon=t

v1.0.0が更新されたが、キャッシュが更新されずに `not found` になっている

<img width="1050" height="240" alt="Screen Shot 2025-08-27 11 46 58" src="https://github.com/user-attachments/assets/e52ea86f-7385-4534-ad6f-fd905e6fabcc" />

badgeに`npm`のロゴを表示できるので、表示する。（副次的にキャッシュ問題も解消される）

## What

<!-- What is a solution you want to add? -->
<img width="1052" height="242" alt="Screen Shot 2025-08-27 11 48 39" src="https://github.com/user-attachments/assets/07264070-fa8b-4414-8744-4ab4a740deed" />



## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
