### PR TITLE
feat: add field type descriptions to filtersSchema operators

### DIFF
--- a/src/tools/kintone/record/__tests__/get-records.test.ts
+++ b/src/tools/kintone/record/__tests__/get-records.test.ts
@@ -32,7 +32,7 @@ describe("get-records tool", () => {
 
     it("should have correct description", () => {
       expect(getRecords.config.description).toBe(
-        "Get multiple records from a kintone app with structured filtering. Use kintone-get-form-fields tool first to discover available fields and their types.",
+        "Get multiple records from a kintone app with structured filtering. All filter conditions are AND-combined; OR conditions are not supported by this MCP server. Use kintone-get-form-fields tool first to discover available fields and their types.",
       );
     });
 

--- a/src/tools/kintone/record/get-records.ts
+++ b/src/tools/kintone/record/get-records.ts
@@ -82,7 +82,7 @@ const filtersSchema = z
   })
   .optional()
   .describe(
-    "Filter conditions for records. Use kintone-get-form-fields tool to discover available field codes and types for an app",
+    "Filter conditions for records. All conditions are AND-combined. NOTE: This MCP server does not currently support OR conditions in filters. Use kintone-get-form-fields tool to discover available field codes and types for an app",
   );
 
 const orderBySchema = z
@@ -172,7 +172,7 @@ const toolName = "kintone-get-records";
 const toolConfig = {
   title: "Get Records",
   description:
-    "Get multiple records from a kintone app with structured filtering. Use kintone-get-form-fields tool first to discover available fields and their types.",
+    "Get multiple records from a kintone app with structured filtering. All filter conditions are AND-combined; OR conditions are not supported by this MCP server. Use kintone-get-form-fields tool first to discover available fields and their types.",
   inputSchema,
   outputSchema,
 };


### PR DESCRIPTION
## Summary

#96

- `get-records`ツールの`filtersSchema`の各フィルターに、対応するフィールドタイプをdescriptionとして追加
- AIがフィールドタイプと演算子の対応関係を判別できるように改善

## 変更内容

| フィルター | 追加したdescription |
|-----------|-------------------|
| textContains | `(like operator). Supported fields: SINGLE_LINE_TEXT, LINK, MULTI_LINE_TEXT, RICH_TEXT, ATTACHMENT` |
| equals | `(= operator). Supported fields: RECORD_NUMBER, SINGLE_LINE_TEXT, LINK, NUMBER, CALC, DATE, TIME, DATETIME, CREATED_TIME, UPDATED_TIME, STATUS` |
| dateRange | `(>=, <= operators). Supported fields: DATE, TIME, DATETIME, CREATED_TIME, UPDATED_TIME` |
| numberRange | `(>=, <= operators). Supported fields: RECORD_NUMBER, $id, NUMBER, CALC` |
| inValues | `(in operator). Supported fields: RECORD_NUMBER, $id, SINGLE_LINE_TEXT, LINK, NUMBER, CALC, CHECK_BOX, RADIO_BUTTON, DROP_DOWN, MULTI_SELECT, USER_SELECT, ORGANIZATION_SELECT, GROUP_SELECT, STATUS, CREATOR, MODIFIER` |
| notInValues | `(not in operator). Supported fields: ...` (inValuesと同じ) |

## 参考

- [kintone クエリの書き方](https://cybozu.dev/ja/kintone/docs/overview/query/)

## Test plan

- [x] pnpm test
- [x] pnpm typecheck
- [x] pnpm fix (lint/format)