### PR TITLE
chore: add minimumReleaseAge and automerge settings for pnpm

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,13 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
     },
+    {
+      description: "Automerge pnpm minor and patch updates",
+      matchPackageNames: ["pnpm"],
+      minimumReleaseAge: "14 days",
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
   ],
   "git-submodules": {
     enabled: true,


### PR DESCRIPTION
## Why

package.jsonのpnpmはcybozu/renovate-configで`minimumReleaseAge: 14 days`が適用されているが、mise.tomlのpnpmには適用されていなかったため、更新タイミングがずれる可能性があった。

https://github.com/kintone/mcp-server/pull/225

## What

mise.tomlとpackage.json両方のpnpmに対して、Renovateの設定を統一:
- `minimumReleaseAge: 14 days`を適用
- minor/patchの更新に対してautomergeを有効化

## How to test

- Renovateが正しく設定を認識することを確認

## Checklist

- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.