### PR TITLE
chore: update trivy to latest

### DIFF
--- a/.github/workflows/yamory-scan.yaml
+++ b/.github/workflows/yamory-scan.yaml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Setup trivy
         env:
-          TRIVY_VERSION: 0.36.1
-          TRIVY_CHECKSUM: 332da8e456e2ae1b5bc02ba7e7c24d2210e04ce06c67bef1f43fe4fec4482875
+          TRIVY_VERSION: 0.69.3
+          TRIVY_CHECKSUM: a484057aafde31089cf2558ca0f79a4bc835125a5ee6834183a5bcf0735af358
         run: |
           wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
           echo "${TRIVY_CHECKSUM}  trivy_${TRIVY_VERSION}_Linux-64bit.deb" > trivy-sha256sum.txt

--- a/.github/workflows/yamory-scan.yaml
+++ b/.github/workflows/yamory-scan.yaml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Setup trivy
         env:
-          TRIVY_VERSION: 0.69.3
-          TRIVY_CHECKSUM: a484057aafde31089cf2558ca0f79a4bc835125a5ee6834183a5bcf0735af358
+          TRIVY_VERSION: 0.72.0
+          TRIVY_CHECKSUM: 9bf8aba92f524b74f8e83d53b298a7dfc6b4d60aca779217e7817e5433c73eeb
         run: |
           wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
           echo "${TRIVY_CHECKSUM}  trivy_${TRIVY_VERSION}_Linux-64bit.deb" > trivy-sha256sum.txt


### PR DESCRIPTION
## Why

The Trivy vulnerability scanner used in the yamory-scan workflow was significantly outdated. Updating to the latest version ensures:

- More accurate vulnerability detection with updated vulnerability database
- Improved scanning performance and reliability
- Access to new features and bug fixes released since v0.36.1

## What

- Updated Trivy version from `0.36.1` to `0.72.0` in `.github/workflows/yamory-scan.yaml`
- Updated SHA256 checksum for the new version

## How to test

1. Trigger the yamory-scan workflow by publishing a container image
2. Verify the workflow completes successfully with the new Trivy version
3. Confirm the vulnerability scan results are generated correctly

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.

## TODO

- [ ] マージ後、GitHub リポジトリ設定の Actions ページから `yamory-scan` ワークフローを GUI で有効化する