### PR TITLE
chore: add Takumi Guard npm security scanning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:mcpb
       - uses: actions/upload-artifact@v6
@@ -44,7 +44,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm pack
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-mcpb:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -16,6 +19,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:mcpb
       - uses: actions/upload-artifact@v6
@@ -26,6 +32,9 @@ jobs:
 
   build-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -33,6 +42,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm pack
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
@@ -39,7 +39,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
@@ -57,7 +57,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
 
@@ -75,7 +75,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm check:mcpb
 
@@ -93,7 +93,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm license:analyze
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -73,7 +73,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -91,7 +91,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -16,11 +19,17 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -28,11 +37,17 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
   typecheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -40,11 +55,17 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
 
   check-mcpb:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -52,11 +73,17 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm check:mcpb
 
   license-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -64,6 +91,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm license:analyze
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       max-parallel: 1
       matrix:
@@ -31,6 +34,11 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+
+      - name: Setup Takumi Guard
+        uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,7 +36,7 @@ jobs:
           cache: "pnpm"
 
       - name: Setup Takumi Guard
-        uses: flatt-security/setup-takumi-guard-npm@v1
+        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -18,6 +21,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - name: Validate PR title
         env:

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - name: Validate PR title
         env:

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # To upload release assets
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -51,6 +52,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:mcpb
       - env:
@@ -76,11 +80,14 @@ jobs:
           node-version-file: .node-version
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - run: npm install -g npm@11.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm publish --access public
+      - run: pnpm publish --access public --registry https://registry.npmjs.org/
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:mcpb
       - env:
@@ -82,7 +82,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - run: npm install -g npm@11.5.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
@@ -80,7 +80,7 @@ jobs:
           node-version-file: .node-version
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       # Ensure npm 11.5.1 or later is installed


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

To strengthen security against npm supply chain attacks by introducing [Takumi Guard](https://github.com/flatt-security/setup-takumi-guard-npm) into the CI/CD pipeline.
Takumi Guard monitors packages installed during `pnpm install` and detects the inclusion of malicious packages.

## What

- Added `flatt-security/setup-takumi-guard-npm` (SHA-pinned, v1.1.1) to all GitHub Actions workflows
  - `build.yaml` (build-mcpb, build-npm)
  - `ci.yaml` (test, lint, typecheck, check-mcpb, license-check)
  - `e2e.yaml` (e2e-test)
  - `lint-pr.yaml` (validate-pr-title)
  - `release.yaml` (build-and-upload-mcpb-to-release, publish-npm-package)
- Added `permissions` (`contents: read`, `id-token: write`) to each job for OIDC authentication
- Fork PRs fall back to anonymous mode (empty bot-id) since secrets are not available
- Added `--registry https://registry.npmjs.org/` to the `pnpm publish` command in `release.yaml` to bypass the read-only proxy

## How to test

- [ ] Verify that all CI workflows run successfully
- [ ] Confirm that the Takumi Guard setup step completes without errors
- [ ] Confirm that `pnpm publish` correctly publishes to the official npm registry (during release)

## Checklist

- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.