### PR TITLE
fix(schema): allow null values for referenceTable and lookup in app field properties

### DIFF
--- a/src/schema/app/field-properties.ts
+++ b/src/schema/app/field-properties.ts
@@ -165,7 +165,8 @@ const subtableFieldProperties = {
         .describe("Query condition to filter lookup results"),
       sort: z.string().optional().describe("Sort order for lookup results"),
     })
-    .optional()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe(
       "Lookup configuration to retrieve values from related app records",
     ),
@@ -194,7 +195,8 @@ const subtableFieldProperties = {
         .optional()
         .describe("Number of records to display per page"),
     })
-    .optional()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe(
       "Configuration for REFERENCE_TABLE field to display related app records",
     ),
@@ -370,7 +372,8 @@ export const baseFieldProperties = {
         .describe("Query condition to filter lookup results"),
       sort: z.string().optional().describe("Sort order for lookup results"),
     })
-    .optional()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe(
       "Lookup configuration to retrieve values from related app records",
     ),
@@ -399,7 +402,8 @@ export const baseFieldProperties = {
         .optional()
         .describe("Number of records to display per page"),
     })
-    .optional()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe(
       "Configuration for REFERENCE_TABLE field to display related app records",
     ),

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -625,7 +625,8 @@ const referenceTableSchema = z.object({
         .enum(["1", "3", "5", "10", "20", "30", "40", "50"])
         .describe("Number of records to display"),
     })
-    .optional()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe("Related records list configuration"),
 });
 
@@ -674,6 +675,8 @@ const lookupSchema = z.object({
         .describe("Query for filtering records in the referenced app"),
       sort: z.string().describe("Sort condition"),
     })
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe("Lookup configuration"),
 });
 

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -675,8 +675,7 @@ const lookupSchema = z.object({
         .describe("Query for filtering records in the referenced app"),
       sort: z.string().describe("Sort condition"),
     })
-    .nullish()
-    .transform((val) => (val === null ? undefined : val))
+    .nullable()
     .describe("Lookup configuration"),
 });
 

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -675,7 +675,8 @@ const lookupSchema = z.object({
         .describe("Query for filtering records in the referenced app"),
       sort: z.string().describe("Sort condition"),
     })
-    .nullable()
+    .nullish()
+    .transform((val) => (val === null ? undefined : val))
     .describe("Lookup configuration"),
 });
 

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -675,7 +675,7 @@ const lookupSchema = z.object({
         .describe("Query for filtering records in the referenced app"),
       sort: z.string().describe("Sort condition"),
     })
-    .nullish()
+    .nullable()
     .transform((val) => (val === null ? undefined : val))
     .describe("Lookup configuration"),
 });


### PR DESCRIPTION
## Why

Kintone の `get-form-fields` API は、関連レコード一覧（`REFERENCE_TABLE`）やルックアップ（`LOOKUP`）の構成情報が設定されていない場合や権限が制限されている場合に、`null` を返すことがあります。
現在の Zod スキーマでは `null` を許容していないため、これらのフィールドが含まれるアプリでツールを実行すると、MCP バリデーションエラー（-32602）が発生していました。

## What

- `properties-parameter.ts` および `field-properties.ts` の Zod スキーマにおいて、`referenceTable` と `lookup` プロパティに `.nullish()` を追加し、`null` を受け入れられるようにしました。
- 同時に `.transform()` を使用して、受け取った `null` を内部的に `undefined` へ変換するようにしました。これにより、`PropertiesForParameter` 型（Kintone SDK の型定義）との互換性が保たれ、`add-form-fields` などの他ツールでビルドエラーが発生しないようになっています。

## How to test

1. 関連レコード一覧やルックアップが設定されているアプリ（または `referenceTable` が `null` で返る状態のアプリ）に対して `kintone-get-form-fields` ツールを実行し、バリデーションエラーが発生しないことを確認します。
2. `pnpm build` または `pnpm build:mcpb` を実行し、TypeScript のコンパイルエラーが発生しないことを確認します。

## Checklist

- [x] Updated documentation if it is required. (N/A)
- [x] Added tests if it is required. (N/A - Schema fix)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.