### PR TITLE
feat: add kintone record comment tools (get/add)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-update-records`          | 複数のレコードを更新                   |
 | `kintone-delete-records`          | 複数のレコードを削除                   |
 | `kintone-update-statuses`         | 複数のレコードのステータスを更新       |
+| `kintone-get-record-comments`     | レコードのコメントを取得               |
+| `kintone-add-record-comment`      | レコードにコメントを追加               |
 | `kintone-add-app`                 | 動作テスト環境にアプリを作成           |
 | `kintone-deploy-app`              | アプリ設定を運用環境へ反映             |
 | `kintone-update-general-settings` | アプリの一般設定を変更                 |

--- a/README_en.md
+++ b/README_en.md
@@ -218,6 +218,8 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-update-records`          | Update multiple records                            |
 | `kintone-delete-records`          | Delete multiple records                            |
 | `kintone-update-statuses`         | Update status of multiple records                  |
+| `kintone-get-record-comments`     | Get comments on a record                           |
+| `kintone-add-record-comment`      | Add a comment to a record                          |
 | `kintone-add-app`                 | Create app in pre-live environment                 |
 | `kintone-deploy-app`              | Deploy app settings to production                  |
 | `kintone-update-general-settings` | Update app general settings                        |

--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,14 @@
       "description": "Delete multiple records from a Kintone app"
     },
     {
+      "name": "kintone-get-record-comments",
+      "description": "Get comments posted on a single kintone record"
+    },
+    {
+      "name": "kintone-add-record-comment",
+      "description": "Add a single comment to a kintone record"
+    },
+    {
       "name": "kintone-update-statuses",
       "description": "Update status of multiple records in a Kintone app"
     },

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -14,6 +14,7 @@ export const createMockClient = (): KintoneRestAPIClient =>
       deleteRecords: vi.fn(),
       updateStatus: vi.fn(),
       updateRecordsStatus: vi.fn(),
+      getRecordComments: vi.fn(),
     },
     app: {
       getApp: vi.fn(),

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -15,6 +15,7 @@ export const createMockClient = (): KintoneRestAPIClient =>
       updateStatus: vi.fn(),
       updateRecordsStatus: vi.fn(),
       getRecordComments: vi.fn(),
+      addRecordComment: vi.fn(),
     },
     app: {
       getApp: vi.fn(),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "./types/tool.js";
+import { addRecordComment } from "./kintone/record/add-record-comment.js";
 import { addRecords } from "./kintone/record/add-records.js";
 import { deleteRecords } from "./kintone/record/delete-records.js";
 import { getRecordComments } from "./kintone/record/get-record-comments.js";
@@ -39,6 +40,7 @@ export const tools: Array<Tool<any, any>> = [
   deleteRecords,
   getRecords,
   getRecordComments,
+  addRecordComment,
   updateRecords,
   addApp,
   deployApp,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "./types/tool.js";
 import { addRecords } from "./kintone/record/add-records.js";
 import { deleteRecords } from "./kintone/record/delete-records.js";
+import { getRecordComments } from "./kintone/record/get-record-comments.js";
 import { getRecords } from "./kintone/record/get-records.js";
 import { updateRecords } from "./kintone/record/update-records.js";
 import { getApp } from "./kintone/app/get-app.js";
@@ -37,6 +38,7 @@ export const tools: Array<Tool<any, any>> = [
   addRecords,
   deleteRecords,
   getRecords,
+  getRecordComments,
   updateRecords,
   addApp,
   deployApp,

--- a/src/tools/kintone/record/__tests__/add-record-comment.test.ts
+++ b/src/tools/kintone/record/__tests__/add-record-comment.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { addRecordComment } from "../add-record-comment.js";
+import { z } from "zod";
+import {
+  createMockClient,
+  mockKintoneConfig,
+} from "../../../../__tests__/utils.js";
+
+const mockAddRecordComment = vi.fn();
+
+describe("add-record-comment tool", () => {
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      ...mockKintoneConfig,
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("tool configuration", () => {
+    it("should have correct name", () => {
+      expect(addRecordComment.name).toBe("kintone-add-record-comment");
+    });
+
+    it("should have correct description", () => {
+      expect(addRecordComment.config.description).toBe(
+        "Add a single comment to a kintone record. The kintone API accepts one comment per call; to add comments to multiple records, call this tool repeatedly.",
+      );
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const inputSchema = z.object(addRecordComment.config.inputSchema!);
+
+    describe("input schema validation with valid inputs", () => {
+      it.each([
+        {
+          input: { app: "1", record: "10", text: "hello" },
+          description: "minimum required fields",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            text: "hi @sato",
+            mentions: [{ code: "sato", type: "USER" }],
+          },
+          description: "with single user mention",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            text: "hi @sato @sales @hq",
+            mentions: [
+              { code: "sato", type: "USER" },
+              { code: "sales", type: "GROUP" },
+              { code: "hq", type: "ORGANIZATION" },
+            ],
+          },
+          description: "with all mention types",
+        },
+        {
+          input: { app: "1", record: "10", text: "hi", mentions: [] },
+          description: "with empty mentions array",
+        },
+      ])("accepts $description", ({ input }) => {
+        expect(() => inputSchema.parse(input)).not.toThrow();
+      });
+    });
+
+    describe("input schema validation with invalid inputs", () => {
+      it.each([
+        { input: {}, description: "missing all required fields" },
+        {
+          input: { app: "1", record: "10" },
+          description: "missing text",
+        },
+        {
+          input: { app: "1", text: "hi" },
+          description: "missing record",
+        },
+        {
+          input: { record: "10", text: "hi" },
+          description: "missing app",
+        },
+        {
+          input: { app: "1", record: "10", text: "" },
+          description: "empty text",
+        },
+        {
+          input: { app: 1, record: "10", text: "hi" },
+          description: "app as number",
+        },
+        {
+          input: { app: "1", record: 10, text: "hi" },
+          description: "record as number",
+        },
+        {
+          input: { app: "1", record: "10", text: 123 },
+          description: "text as number",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            text: "hi",
+            mentions: [{ code: "sato", type: "ROLE" }],
+          },
+          description: "mention type with invalid value",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            text: "hi",
+            mentions: [{ code: "sato" }],
+          },
+          description: "mention without type",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            text: "hi",
+            mentions: [{ type: "USER" }],
+          },
+          description: "mention without code",
+        },
+      ])("rejects $description", ({ input }) => {
+        expect(() => inputSchema.parse(input)).toThrow();
+      });
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const outputSchema = z.object(addRecordComment.config.outputSchema!);
+
+    describe("output schema validation with valid outputs", () => {
+      it.each([
+        { output: { id: "1" }, description: "numeric string id" },
+        { output: { id: "abc" }, description: "non-numeric id" },
+      ])("accepts $description", ({ output }) => {
+        expect(() => outputSchema.parse(output)).not.toThrow();
+      });
+    });
+
+    describe("output schema validation with invalid outputs", () => {
+      it.each([
+        { output: {}, description: "missing id" },
+        { output: { id: 1 }, description: "id as number" },
+        { output: { id: null }, description: "id as null" },
+      ])("rejects $description", ({ output }) => {
+        expect(() => outputSchema.parse(output)).toThrow();
+      });
+    });
+  });
+
+  describe("callback function", () => {
+    it("should call API with required fields only and return formatted response", async () => {
+      const mockResponse = { id: "5" };
+      mockAddRecordComment.mockResolvedValueOnce(mockResponse);
+
+      const input = { app: "123", record: "10", text: "hello" };
+
+      const mockClient = createMockClient();
+      mockClient.record.addRecordComment = mockAddRecordComment;
+
+      const result = await addRecordComment.callback(input, {
+        client: mockClient,
+      });
+
+      expect(mockAddRecordComment).toHaveBeenCalledWith({
+        app: "123",
+        record: "10",
+        comment: {
+          text: "hello",
+          mentions: undefined,
+        },
+      });
+      expect(result.structuredContent).toEqual(mockResponse);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: "text",
+        text: JSON.stringify(mockResponse, null, 2),
+      });
+    });
+
+    it("should call API with mentions", async () => {
+      const mockResponse = { id: "7" };
+      mockAddRecordComment.mockResolvedValueOnce(mockResponse);
+
+      const input = {
+        app: "456",
+        record: "20",
+        text: "hi @sato @sales",
+        mentions: [
+          { code: "sato", type: "USER" as const },
+          { code: "sales", type: "GROUP" as const },
+        ],
+      };
+
+      const mockClient = createMockClient();
+      mockClient.record.addRecordComment = mockAddRecordComment;
+
+      const result = await addRecordComment.callback(input, {
+        client: mockClient,
+      });
+
+      expect(mockAddRecordComment).toHaveBeenCalledWith({
+        app: "456",
+        record: "20",
+        comment: {
+          text: "hi @sato @sales",
+          mentions: [
+            { code: "sato", type: "USER" },
+            { code: "sales", type: "GROUP" },
+          ],
+        },
+      });
+      expect(result.structuredContent).toEqual(mockResponse);
+    });
+
+    it("should handle API errors properly", async () => {
+      const mockError = new Error("API Error: Record not found");
+      mockAddRecordComment.mockRejectedValueOnce(mockError);
+
+      const input = { app: "123", record: "999", text: "hello" };
+
+      const mockClient = createMockClient();
+      mockClient.record.addRecordComment = mockAddRecordComment;
+
+      await expect(
+        addRecordComment.callback(input, {
+          client: mockClient,
+        }),
+      ).rejects.toThrow("API Error: Record not found");
+    });
+  });
+});

--- a/src/tools/kintone/record/__tests__/get-record-comments.test.ts
+++ b/src/tools/kintone/record/__tests__/get-record-comments.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getRecordComments } from "../get-record-comments.js";
+import { z } from "zod";
+import {
+  createMockClient,
+  mockKintoneConfig,
+} from "../../../../__tests__/utils.js";
+
+const mockGetRecordComments = vi.fn();
+
+describe("get-record-comments tool", () => {
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      ...mockKintoneConfig,
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("tool configuration", () => {
+    it("should have correct name", () => {
+      expect(getRecordComments.name).toBe("kintone-get-record-comments");
+    });
+
+    it("should have correct description", () => {
+      expect(getRecordComments.config.description).toBe(
+        "Get comments posted on a single kintone record. The kintone API returns comments for one record at a time; to fetch comments for multiple records, call this tool repeatedly. Up to 10 comments are returned per call; use offset to paginate.",
+      );
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const inputSchema = z.object(getRecordComments.config.inputSchema!);
+
+    describe("input schema validation with valid inputs", () => {
+      it.each([
+        {
+          input: { app: "1", record: "10" },
+          description: "minimum required fields",
+        },
+        {
+          input: {
+            app: "1",
+            record: "10",
+            order: "asc",
+            limit: 10,
+            offset: 0,
+          },
+          description: "all fields with order asc",
+        },
+        {
+          input: { app: "1", record: "10", order: "desc" },
+          description: "with order desc only",
+        },
+        {
+          input: { app: "1", record: "10", limit: 1 },
+          description: "limit at lower bound",
+        },
+        {
+          input: { app: "1", record: "10", limit: 10 },
+          description: "limit at upper bound",
+        },
+        {
+          input: { app: "1", record: "10", offset: 100 },
+          description: "with large offset",
+        },
+      ])("accepts $description", ({ input }) => {
+        expect(() => inputSchema.parse(input)).not.toThrow();
+      });
+    });
+
+    describe("input schema validation with invalid inputs", () => {
+      it.each([
+        { input: {}, description: "missing all required fields" },
+        { input: { app: "1" }, description: "missing record" },
+        { input: { record: "10" }, description: "missing app" },
+        { input: { app: 1, record: "10" }, description: "app as number" },
+        { input: { app: null, record: "10" }, description: "app as null" },
+        { input: { app: true, record: "10" }, description: "app as boolean" },
+        { input: { app: "1", record: 10 }, description: "record as number" },
+        {
+          input: { app: "1", record: "10", order: "ascending" },
+          description: "order with invalid value",
+        },
+        {
+          input: { app: "1", record: "10", limit: 0 },
+          description: "limit below minimum",
+        },
+        {
+          input: { app: "1", record: "10", limit: 11 },
+          description: "limit above maximum",
+        },
+        {
+          input: { app: "1", record: "10", offset: -1 },
+          description: "negative offset",
+        },
+      ])("rejects $description", ({ input }) => {
+        expect(() => inputSchema.parse(input)).toThrow();
+      });
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const outputSchema = z.object(getRecordComments.config.outputSchema!);
+
+    describe("output schema validation with valid outputs", () => {
+      it.each([
+        {
+          output: {
+            comments: [],
+            older: false,
+            newer: false,
+          },
+          description: "empty comments",
+        },
+        {
+          output: {
+            comments: [
+              {
+                id: "1",
+                text: "hello",
+                createdAt: "2026-04-25T10:00:00Z",
+                creator: { code: "user1", name: "User One" },
+                mentions: [],
+              },
+            ],
+            older: false,
+            newer: true,
+          },
+          description: "single comment without mentions",
+        },
+        {
+          output: {
+            comments: [
+              {
+                id: "1",
+                text: "hi @group1 @user2",
+                createdAt: "2026-04-25T10:00:00Z",
+                creator: { code: "user1", name: "User One" },
+                mentions: [
+                  { code: "group1", type: "GROUP" },
+                  { code: "user2", type: "USER" },
+                  { code: "org1", type: "ORGANIZATION" },
+                ],
+              },
+            ],
+            older: true,
+            newer: false,
+          },
+          description: "comment with multiple mention types",
+        },
+      ])("accepts $description", ({ output }) => {
+        expect(() => outputSchema.parse(output)).not.toThrow();
+      });
+    });
+
+    describe("output schema validation with invalid outputs", () => {
+      it.each([
+        { output: {}, description: "missing required fields" },
+        {
+          output: { comments: [], older: false },
+          description: "missing newer",
+        },
+        {
+          output: { comments: null, older: false, newer: false },
+          description: "comments as null",
+        },
+        {
+          output: { comments: [], older: "false", newer: false },
+          description: "older as string",
+        },
+        {
+          output: {
+            comments: [
+              {
+                id: "1",
+                text: "hi",
+                createdAt: "2026-04-25T10:00:00Z",
+                creator: { code: "u1", name: "n" },
+                mentions: [{ code: "x", type: "ROLE" }],
+              },
+            ],
+            older: false,
+            newer: false,
+          },
+          description: "mention type with invalid value",
+        },
+        {
+          output: {
+            comments: [
+              {
+                id: 1,
+                text: "hi",
+                createdAt: "2026-04-25T10:00:00Z",
+                creator: { code: "u1", name: "n" },
+                mentions: [],
+              },
+            ],
+            older: false,
+            newer: false,
+          },
+          description: "comment id as number",
+        },
+      ])("rejects $description", ({ output }) => {
+        expect(() => outputSchema.parse(output)).toThrow();
+      });
+    });
+  });
+
+  describe("callback function", () => {
+    it("should call API with required fields only and return formatted response", async () => {
+      const mockResponse = {
+        comments: [
+          {
+            id: "1",
+            text: "first comment",
+            createdAt: "2026-04-25T10:00:00Z",
+            creator: { code: "user1", name: "User One" },
+            mentions: [],
+          },
+        ],
+        older: false,
+        newer: false,
+      };
+
+      mockGetRecordComments.mockResolvedValueOnce(mockResponse);
+
+      const input = { app: "123", record: "10" };
+
+      const mockClient = createMockClient();
+      mockClient.record.getRecordComments = mockGetRecordComments;
+
+      const result = await getRecordComments.callback(input, {
+        client: mockClient,
+      });
+
+      expect(mockGetRecordComments).toHaveBeenCalledWith({
+        app: "123",
+        record: "10",
+        order: undefined,
+        limit: undefined,
+        offset: undefined,
+      });
+      expect(result.structuredContent).toEqual(mockResponse);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: "text",
+        text: JSON.stringify(mockResponse, null, 2),
+      });
+    });
+
+    it("should call API with all parameters", async () => {
+      const mockResponse = {
+        comments: [
+          {
+            id: "5",
+            text: "newest comment",
+            createdAt: "2026-04-25T12:00:00Z",
+            creator: { code: "user2", name: "User Two" },
+            mentions: [{ code: "user1", type: "USER" }],
+          },
+        ],
+        older: true,
+        newer: false,
+      };
+
+      mockGetRecordComments.mockResolvedValueOnce(mockResponse);
+
+      const input = {
+        app: "456",
+        record: "20",
+        order: "desc" as const,
+        limit: 5,
+        offset: 10,
+      };
+
+      const mockClient = createMockClient();
+      mockClient.record.getRecordComments = mockGetRecordComments;
+
+      const result = await getRecordComments.callback(input, {
+        client: mockClient,
+      });
+
+      expect(mockGetRecordComments).toHaveBeenCalledWith({
+        app: "456",
+        record: "20",
+        order: "desc",
+        limit: 5,
+        offset: 10,
+      });
+      expect(result.structuredContent).toEqual(mockResponse);
+    });
+
+    it("should handle empty comments response", async () => {
+      const mockResponse = {
+        comments: [],
+        older: false,
+        newer: false,
+      };
+
+      mockGetRecordComments.mockResolvedValueOnce(mockResponse);
+
+      const input = { app: "123", record: "10" };
+
+      const mockClient = createMockClient();
+      mockClient.record.getRecordComments = mockGetRecordComments;
+
+      const result = await getRecordComments.callback(input, {
+        client: mockClient,
+      });
+
+      expect(result.structuredContent).toEqual(mockResponse);
+    });
+
+    it("should handle API errors properly", async () => {
+      const mockError = new Error("API Error: Record not found");
+      mockGetRecordComments.mockRejectedValueOnce(mockError);
+
+      const input = { app: "123", record: "999" };
+
+      const mockClient = createMockClient();
+      mockClient.record.getRecordComments = mockGetRecordComments;
+
+      await expect(
+        getRecordComments.callback(input, {
+          client: mockClient,
+        }),
+      ).rejects.toThrow("API Error: Record not found");
+    });
+  });
+});

--- a/src/tools/kintone/record/add-record-comment.ts
+++ b/src/tools/kintone/record/add-record-comment.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { createTool } from "../../factory.js";
+import type { KintoneToolCallback } from "../../types/tool.js";
+
+const mentionSchema = z.object({
+  code: z
+    .string()
+    .describe(
+      "Login name (for USER), group/role code (for GROUP), or organization code (for ORGANIZATION). Display names are not accepted.",
+    ),
+  type: z
+    .enum(["USER", "GROUP", "ORGANIZATION"])
+    .describe("Type of the mention target"),
+});
+
+const inputSchema = {
+  app: z
+    .string()
+    .describe(
+      "The ID of the app that contains the record (numeric value as string)",
+    ),
+  record: z.string().describe("The ID of the record to add a comment to"),
+  text: z
+    .string()
+    .min(1)
+    .describe(
+      "Comment text. To mention users/groups/organizations, include '@code' tokens here and list the corresponding entries in 'mentions'.",
+    ),
+  mentions: z
+    .array(mentionSchema)
+    .optional()
+    .describe(
+      "Mentions to attach to the comment. Each entry pairs a code with its type (USER/GROUP/ORGANIZATION).",
+    ),
+};
+
+const outputSchema = {
+  id: z.string().describe("ID of the added comment"),
+};
+
+const toolName = "kintone-add-record-comment";
+const toolConfig = {
+  title: "Add Record Comment",
+  description:
+    "Add a single comment to a kintone record. The kintone API accepts one comment per call; to add comments to multiple records, call this tool repeatedly.",
+  inputSchema,
+  outputSchema,
+};
+
+const callback: KintoneToolCallback<typeof inputSchema> = async (
+  { app, record, text, mentions },
+  { client },
+) => {
+  const response = await client.record.addRecordComment({
+    app,
+    record,
+    comment: {
+      text,
+      mentions,
+    },
+  });
+
+  const result = {
+    id: response.id,
+  };
+
+  return {
+    structuredContent: result,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+};
+
+export const addRecordComment = createTool(toolName, toolConfig, callback);

--- a/src/tools/kintone/record/add-record-comment.ts
+++ b/src/tools/kintone/record/add-record-comment.ts
@@ -25,7 +25,7 @@ const inputSchema = {
     .min(1)
     .max(65535)
     .describe(
-      "Comment text. To mention users/groups/organizations, include '@code' tokens here and list the corresponding entries in 'mentions'.",
+      "Comment text. To mention users/groups/organizations, list the corresponding entries in 'mentions'. Do NOT include '@code' tokens in this text — not even as a greeting prefix such as '@user1 さん、' or '@group_name '. Mentions specified via the 'mentions' parameter are auto-rendered into the posted comment by kintone; any '@code' written in this text becomes a plain-text literal that does not link, does not notify, and visually duplicates the auto-rendered mention.",
     ),
   mentions: z
     .array(mentionSchema)

--- a/src/tools/kintone/record/add-record-comment.ts
+++ b/src/tools/kintone/record/add-record-comment.ts
@@ -23,6 +23,7 @@ const inputSchema = {
   text: z
     .string()
     .min(1)
+    .max(65535)
     .describe(
       "Comment text. To mention users/groups/organizations, include '@code' tokens here and list the corresponding entries in 'mentions'.",
     ),

--- a/src/tools/kintone/record/get-record-comments.ts
+++ b/src/tools/kintone/record/get-record-comments.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { createTool } from "../../factory.js";
+import type { KintoneToolCallback } from "../../types/tool.js";
+
+const inputSchema = {
+  app: z
+    .string()
+    .describe(
+      "The ID of the app that contains the record (numeric value as string)",
+    ),
+  record: z.string().describe("The ID of the record to retrieve comments from"),
+  order: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe(
+      "Sort order of comments by createdAt. 'asc' = oldest first, 'desc' = newest first (default: desc)",
+    ),
+  limit: z
+    .number()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe(
+      "Maximum number of comments to retrieve (1-10, default: 10 by kintone API)",
+    ),
+  offset: z
+    .number()
+    .min(0)
+    .optional()
+    .describe("Number of comments to skip (default: 0)"),
+};
+
+const commentSchema = z.object({
+  id: z.string().describe("Comment ID"),
+  text: z.string().describe("Comment text"),
+  createdAt: z.string().describe("Comment creation datetime (ISO 8601)"),
+  creator: z
+    .object({
+      code: z.string().describe("User code of the comment creator"),
+      name: z.string().describe("Display name of the comment creator"),
+    })
+    .describe("Information about the comment creator"),
+  mentions: z
+    .array(
+      z.object({
+        code: z.string().describe("Code of the mentioned user/group/org"),
+        type: z
+          .enum(["USER", "GROUP", "ORGANIZATION"])
+          .describe("Type of the mention target"),
+      }),
+    )
+    .describe("Mentions in the comment"),
+});
+
+const outputSchema = {
+  comments: z.array(commentSchema).describe("Array of comments on the record"),
+  older: z
+    .boolean()
+    .describe("Whether there are older comments beyond this page"),
+  newer: z
+    .boolean()
+    .describe("Whether there are newer comments beyond this page"),
+};
+
+const toolName = "kintone-get-record-comments";
+const toolConfig = {
+  title: "Get Record Comments",
+  description:
+    "Get comments posted on a single kintone record. The kintone API returns comments for one record at a time; to fetch comments for multiple records, call this tool repeatedly. Up to 10 comments are returned per call; use offset to paginate.",
+  inputSchema,
+  outputSchema,
+};
+
+const callback: KintoneToolCallback<typeof inputSchema> = async (
+  { app, record, order, limit, offset },
+  { client },
+) => {
+  const response = await client.record.getRecordComments({
+    app,
+    record,
+    order,
+    limit,
+    offset,
+  });
+
+  const result = {
+    comments: response.comments,
+    older: response.older,
+    newer: response.newer,
+  };
+
+  return {
+    structuredContent: result,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+};
+
+export const getRecordComments = createTool(toolName, toolConfig, callback);


### PR DESCRIPTION
## Why

The kintone record-operation MCP tools (`get-records` / `add-records` / `update-records` / `delete-records` / `update-statuses`) are already in place, but **tools for retrieving and adding record comments were missing**.

By enabling AI agents to read record comment history (conversations, mentions, decision context, etc.) and to post comments such as review requests, this change supports use cases like situation awareness, summarization, follow-up gap detection, and assigning actions.

## What

Added two MCP tools that wrap `client.record.getRecordComments` / `client.record.addRecordComment` from `@kintone/rest-api-client`.

### `kintone-get-record-comments`

- **Input**
  - `app` (required): App ID
  - `record` (required): Record ID
  - `order`: `"asc"` | `"desc"` (optional, aligned with the kintone API key name `order`)
  - `limit`: 1–10 (optional, the upper bound defined by the kintone API)
  - `offset`: 0 or greater (optional)
- **Output**
  - `comments[]`: `id` / `text` / `createdAt` / `creator{code,name}` / `mentions[]{code,type}`
  - `older`: Whether there are older comments beyond this page
  - `newer`: Whether there are newer comments beyond this page

### `kintone-add-record-comment`

- **Input**
  - `app` (required): App ID
  - `record` (required): Record ID
  - `text` (required): Comment body (empty string not allowed)
  - `mentions` (optional): `[{ code, type: "USER" | "GROUP" | "ORGANIZATION" }]`
    - For `code`, specify the **login name / group (role) code / organization code**, not the display name
- **Output**
  - `id`: ID of the added comment

In line with the kintone API specification, both tools operate on a single record at a time; iterating over multiple records is left to the caller.

### Changed files

- New `src/tools/kintone/record/get-record-comments.ts`
- New `src/tools/kintone/record/add-record-comment.ts`
- New `src/tools/kintone/record/__tests__/get-record-comments.test.ts`
- New `src/tools/kintone/record/__tests__/add-record-comment.test.ts`
- Modified `src/tools/index.ts` (import / registration in the `tools` array)
- Modified `src/__tests__/utils.ts` (added `getRecordComments` / `addRecordComment` to `createMockClient.record`)
- Modified `README.md` / `README_en.md` (added the two new tools to the tool list table)

## How to test

1. `pnpm install`
2. `pnpm lint` — no errors
3. `pnpm typecheck` — no type errors
4. `pnpm test` — all 608 tests pass
5. (Optional, real environment) Configure `.env` and invoke the tools from an MCP client to verify behavior

   Get comments:

   ```json
   {
     "name": "kintone-get-record-comments",
     "arguments": { "app": "1", "record": "10" }
   }
   ```

   Add a comment:

   ```json
   {
     "name": "kintone-add-record-comment",
     "arguments": {
       "app": "1",
       "record": "10",
       "text": "@sato Please review",
       "mentions": [{ "code": "sato", "type": "USER" }]
     }
   }
   ```

## Checklist

- [x] Updated documentation if it is required. (Added entries to the tool list table in README.md / README_en.md)
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
