### PR TITLE
fix(ci): remove unused id-token: write and pnpm cache from release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -34,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -29,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -47,7 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -65,7 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -83,7 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # To upload release assets
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-          cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
@@ -78,7 +77,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-          cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:


### PR DESCRIPTION
## 概要

[TanStack の npm サプライチェーン侵害事案（2026-05-11）](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) と同型の攻撃ベクトルを緩和する予防的なハードニング。本リポジトリで侵害痕跡（IOC）は検出されていない。

TanStack 事案は以下3つの脆弱性を連鎖させた攻撃だった:
1. `pull_request_target` ワークフローで fork のコードが実行される（Pwn Request）
2. **PR ↔ release ワークフロー間で GitHub Actions キャッシュが汚染される**
3. **`id-token: write` を持つランナーから OIDC トークンが抽出される**

このPRでは項目 2 と 3 の経路を遮断する。

## 変更内容

- **`release.yaml` の `build-and-upload-mcpb-to-release` および `publish-npm-package` 両ジョブから `cache: "pnpm"` を削除。** `cache: "pnpm"` を有効にすると `setup-node` は `pnpm-lock.yaml` のハッシュからキャッシュキーを導出するため、悪意ある fork PR がキャッシュを汚染した場合、次の `release.yaml` 実行（main 上）が汚染キャッシュを復元してから `pnpm install --frozen-lockfile && pnpm build && pnpm publish` を走らせるという経路が成立してしまう。キャッシュを使わなければこの経路自体が消える。
- **publish 以外のジョブから `id-token: write` を削除**:
  - `ci.yaml`, `build.yaml`, `e2e.yaml`, `lint-pr.yaml`: これらのジョブは OIDC を使わない
  - `release.yaml` の `build-and-upload-mcpb-to-release`: `pnpm build:mcpb` は単に `mcpb pack` でパッケージングするのみで Sigstore 等の署名は行わず、`gh release upload` も `GITHUB_TOKEN` で認証するため OIDC 不要
- 最小権限の原則に従い、`release.yaml` の `publish-npm-package` ジョブのみ `id-token: write` を残す（npm Trusted Publishing と provenance に必須）。

## Trusted Publishing を使っていてもなぜ重要か

Trusted Publishing なので長期 `NODE_AUTH_TOKEN` の窃取リスクはない。しかしキャッシュ汚染攻撃はトークンを盗む必要がない — release ランナー上で `pnpm install` / `pnpm build` 中に悪意あるコードを実行させれば、`pnpm publish` がそのコードを正規の OIDC トークンで npm に公開してしまう。キャッシュを切ればこの連鎖が断たれる。

## テスト方針

- [ ] このPRで ci, build, e2e, lint-pr の各ワークフローを再実行し、権限を絞った状態でもパスすることを確認
- [ ] マージ後、次のリリースで publish / mcpb-upload 挙動にリグレッションがないか監視

BEGIN_COMMIT_OVERRIDE
chore(ci): remove unused id-token: write and pnpm cache from release
END_COMMIT_OVERRIDE