### PR TITLE
fix: use --node-linker=hoisted instead of --shamefully-hoist

### DIFF
--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -20,7 +20,7 @@ cp package.json \
    build/tmp/
 cp -r dist build/tmp/
 
-pnpm --prefix build/tmp install --prod --frozen-lockfile --shamefully-hoist
+pnpm --prefix build/tmp install --prod --frozen-lockfile --node-linker=hoisted
 
 pnpm mcpb pack build/tmp build/kintone-mcp-server.mcpb
 


### PR DESCRIPTION
## Why

When using the MCP server via mcpb in Claude Desktop with `HTTPS_PROXY` configured,
every kintone API call fails with:

```
TypeError: Right-hand side of 'instanceof' is not callable
```

**Root cause:**

`build-mcpb.sh` used `pnpm install --shamefully-hoist`, which keeps the `.pnpm/`
virtual store and adds top-level symlinks on top of it. When `mcpb pack` resolves
symlinks into physical file copies, `axios.cjs` (bundled inside
`@kintone/rest-api-client`) ends up at a physical path under
`.pnpm/@kintone+rest-api-client@*/node_modules/axios/`.

Node.js's CJS module resolution skips directories named `node_modules` when
walking up the directory tree, so it cannot find axios's own nested
`https-proxy-agent@5.0.1`. It falls back to the top-level `https-proxy-agent@7.0.6`,
whose `require()` returns a plain object `{ HttpsProxyAgent: class }` instead of
the class directly. This causes `instanceof` to throw.

This was triggered by the `@kintone/rest-api-client@6.1.7` update (#444), which
upgraded axios from `1.15.0` to `1.16.1`. `axios@1.16.1` added
`https-proxy-agent@^5.0.1` as a dependency and introduced an
`instanceof HttpsProxyAgent` check inside `setProxy()`.

## What

Replace `--shamefully-hoist` with `--node-linker=hoisted` in `build-mcpb.sh`.

`--node-linker=hoisted` produces a fully flat, npm-compatible `node_modules/`
without a `.pnpm/` virtual store. Version conflicts are resolved by placing the
minority version inside the dependent package's own `node_modules/` (e.g.,
`node_modules/axios/node_modules/https-proxy-agent/` for v5.0.1), which axios
can find correctly.

As a side effect, the mcpb package size drops from **14.8 MB → 4.5 MB** (3×
smaller), since `--shamefully-hoist` was duplicating every file between `.pnpm/`
real files and their resolved copies.

## How to test

1. Build the mcpb package: `pnpm build:mcpb`
2. Install the built `.mcpb` in Claude Desktop
3. Set `HTTPS_PROXY=http://<your-proxy>:<port>` in the MCP server configuration
4. Call any kintone tool (e.g., `kintone-get-app`)
5. Confirm the `instanceof` error no longer appears — a network or authentication
   error from the proxy is expected instead

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
