### PR TITLE
fix: remove stray console.log polluting MCP stdio stream

### DIFF
--- a/src/tools/kintone/app/get-general-settings.ts
+++ b/src/tools/kintone/app/get-general-settings.ts
@@ -99,7 +99,6 @@ const callback: KintoneToolCallback<typeof inputSchema> = async (
   { client },
 ) => {
   const settings = await client.app.getAppSettings({ app, lang, preview });
-  console.log(settings);
 
   const result = {
     name: settings.name,


### PR DESCRIPTION
## Summary

Remove the leftover debug `console.log(settings)` in the `kintone-get-general-settings` tool.

## Problem

An MCP stdio server must emit only JSON-RPC messages on stdout, but this tool wrote the raw `getAppSettings` object to stdout on every call. That corrupted the JSON-RPC stream and triggered parse errors on the client (e.g. Claude Desktop):

```
[error] Invalid JSON-RPC message: { name: '...', description: '...', ... }
```

The tool's return value is still delivered correctly, so the feature works, but the stream is polluted and some clients may drop the connection.

## Cause

Debug logging introduced when the tool was added in `feat: add tools for get app settings (#114)` (470e755) and never removed.

## Fix

Delete the single `console.log(settings);` line in `src/tools/kintone/app/get-general-settings.ts`.

## Verification

- `pnpm test get-general-settings` — 20 passed
- `pnpm typecheck` — passed
- Confirmed no other stdout-polluting output remains in `src` (the remaining `console.error` calls go to stderr, which is fine)