### PR TITLE
docs: add kintone-search tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ kintoneの公式ローカルMCPサーバーです。
 - [ドキュメント](#%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88)
 - [使用上の注意](#%E4%BD%BF%E7%94%A8%E4%B8%8A%E3%81%AE%E6%B3%A8%E6%84%8F)
   - [`kintone-download-file`ツールの注意点](#kintone-download-file%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9)
+  - [`kintone-search`ツールの注意点](#kintone-search%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9)
 - [制限事項](#%E5%88%B6%E9%99%90%E4%BA%8B%E9%A0%85)
   - [レコード操作の制限](#%E3%83%AC%E3%82%B3%E3%83%BC%E3%83%89%E6%93%8D%E4%BD%9C%E3%81%AE%E5%88%B6%E9%99%90)
   - [その他の制限](#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E5%88%B6%E9%99%90)
@@ -215,6 +216,7 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-deploy-app`              | アプリ設定を運用環境へ反映             |
 | `kintone-update-general-settings` | アプリの一般設定を変更                 |
 | `kintone-download-file`           | 添付ファイルフィールドのファイルを保存 |
+| `kintone-search`                  | kintone全体を検索                      |
 
 ## ドキュメント
 
@@ -227,6 +229,10 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 - ダウンロードしたファイルは、`--attachments-dir`または`KINTONE_ATTACHMENTS_DIR`で指定したディレクトリに保存されます。
 - `--attachments-dir`または`KINTONE_ATTACHMENTS_DIR`を指定しない場合はツール実行時にエラーになります。
 - `--attachments-dir`または`KINTONE_ATTACHMENTS_DIR`に存在しないディレクトリを指定した場合は、ディレクトリを新規作成してからそこに保存されます。
+
+### `kintone-search`ツールの注意点
+
+- `kintone-search`は[APIラボの検索API](https://github.com/kintone/js-sdk/blob/main/packages/rest-api-client/docs/search.md)を利用しています。そのため、ツールの挙動は予告なく変更される場合があります。
 
 ## 制限事項
 

--- a/README_en.md
+++ b/README_en.md
@@ -35,6 +35,7 @@ The official local MCP server for Kintone.
 - [Documentation](#documentation)
 - [Notes](#notes)
   - [`kintone-download-file` Tool](#kintone-download-file-tool)
+  - [`kintone-search` Tool](#kintone-search-tool)
 - [Limitations](#limitations)
   - [Record Operation Limitations](#record-operation-limitations)
   - [Other Limitations](#other-limitations)
@@ -224,6 +225,7 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-deploy-app`              | Deploy app settings to production                  |
 | `kintone-update-general-settings` | Update app general settings                        |
 | `kintone-download-file`           | Download and save a file from an attachment field  |
+| `kintone-search`                  | Search across all of kintone                       |
 
 ## Documentation
 
@@ -236,6 +238,10 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 - Downloaded files are saved to the directory specified by `--attachments-dir` or `KINTONE_ATTACHMENTS_DIR`.
 - If `--attachments-dir` or `KINTONE_ATTACHMENTS_DIR` is not specified, an error will occur when executing the tool.
 - If a non-existent directory is specified for `--attachments-dir` or `KINTONE_ATTACHMENTS_DIR`, a new directory will be created and files will be saved there.
+
+### `kintone-search` Tool
+
+- `kintone-search` uses the [API Lab search API](https://github.com/kintone/js-sdk/blob/main/packages/rest-api-client/docs/search.md). As a result, the tool's behavior may change without notice.
 
 ## Limitations
 


### PR DESCRIPTION
## Why

`kintone-search` ツールが実装されているものの、README のツール一覧に記載がなかったため追加します。

## What

- ツール一覧の表に `kintone-search` を追加
- 「使用上の注意」に `kintone-search` ツールの注意点（API ラボの検索 API を利用しているため挙動が変わりうる旨）を追加
- 上記に伴い目次（doctoc）を再生成
- README.md / README_en.md の両方を更新

## How to test

- README.md / README_en.md をプレビューし、ツール一覧の表・注意点セクション・目次のリンクが正しく表示されることを確認

## Checklist

- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.