### PR TITLE
ci: add label-driven Docker snapshot publish/cleanup workflows

### DIFF
--- a/.github/actions/sanitize-snapshot-branch/action.yaml
+++ b/.github/actions/sanitize-snapshot-branch/action.yaml
@@ -1,0 +1,40 @@
+name: Sanitize snapshot branch
+description: >
+  Sanitize a git branch name for use in docker image tags and label-driven snapshot workflows.
+  Strips non-alphanumeric characters (except -), collapses hyphens, and truncates to 50 chars.
+
+inputs:
+  branch:
+    description: Raw git branch name to sanitize
+    required: true
+
+outputs:
+  sanitized-branch:
+    description: Sanitized branch name (safe for docker tags)
+    value: ${{ steps.sanitize.outputs.sanitized-branch }}
+  moving-tag:
+    description: Moving docker tag (snapshot-<sanitized-branch>)
+    value: ${{ steps.sanitize.outputs.moving-tag }}
+  immutable-prefix:
+    description: Prefix for immutable docker tags (<sanitized-branch>-)
+    value: ${{ steps.sanitize.outputs.immutable-prefix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Sanitize
+      id: sanitize
+      shell: bash
+      env:
+        BRANCH_NAME: ${{ inputs.branch }}
+      run: |
+        SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-50 | sed 's/-$//')
+        if [[ -z "$SANITIZED" ]]; then
+          echo "::error::sanitized branch name is empty (input: '${BRANCH_NAME}')"
+          exit 1
+        fi
+        {
+          echo "sanitized-branch=${SANITIZED}"
+          echo "moving-tag=snapshot-${SANITIZED}"
+          echo "immutable-prefix=${SANITIZED}-"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cleanup-all-docker-snapshots.yaml
+++ b/.github/workflows/cleanup-all-docker-snapshots.yaml
@@ -1,0 +1,203 @@
+name: Cleanup all docker snapshots
+
+# Bulk cleanup for mcp-server snapshot images. Defaults to dry-run.
+# When `branch` is empty, all snapshot branches are collected from the registry
+# moving tags and from PRs that currently carry the `snapshot/docker` label.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name to clean up. Empty = all snapshot branches."
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: "List versions and labels but do not delete/remove (default: true)"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: cleanup-all-docker-snapshots
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect snapshot branches
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+    outputs:
+      branches: ${{ steps.collect.outputs.branches }}
+      pr-numbers: ${{ steps.collect.outputs.pr-numbers }}
+    steps:
+      - name: Collect branches and PR numbers
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ORG="kintone"
+          PACKAGE_NAME="mcp-server"
+          LABEL="snapshot/docker"
+
+          sanitize() {
+            echo "$1" | sed 's/[^a-zA-Z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-50 | sed 's/-$//'
+          }
+
+          if [[ -n "$INPUT_BRANCH" ]]; then
+            S=$(sanitize "$INPUT_BRANCH")
+            if [[ -z "$S" ]]; then
+              echo "::error::sanitized branch name is empty (input: '${INPUT_BRANCH}')"
+              exit 1
+            fi
+            echo "$S" > /tmp/all-branches.txt
+          else
+            # 1) Branches inferred from existing moving tags in the registry
+            gh api --paginate "/orgs/${ORG}/packages/container/${PACKAGE_NAME}/versions" \
+              --jq '.[] | .metadata.container.tags[]?' \
+              | grep -E '^snapshot-' \
+              | sed 's/^snapshot-//' \
+              > /tmp/branches-from-tags.txt || true
+
+            # 2) Branches from PRs that currently have the label
+            : > /tmp/branches-from-prs.txt
+            gh pr list --repo "$REPO" --label "$LABEL" --state all --limit 1000 \
+              --json headRefName --jq '.[].headRefName' > /tmp/raw-pr-branches.txt 2>/dev/null || true
+            while IFS= read -r b; do
+              [[ -z "$b" ]] && continue
+              sanitize "$b" >> /tmp/branches-from-prs.txt
+            done < /tmp/raw-pr-branches.txt
+
+            # Use `awk 'NF'` to drop blank lines; `grep -v '^$'` exits 1 on no
+            # matches and would fail the step under `set -o pipefail` when
+            # both files are empty (no snapshots, no labeled PRs).
+            cat /tmp/branches-from-tags.txt /tmp/branches-from-prs.txt \
+              | awk 'NF' \
+              | sort -u > /tmp/all-branches.txt
+          fi
+
+          BRANCH_COUNT=$(wc -l < /tmp/all-branches.txt | tr -d ' ')
+          echo "Branches to clean up: ${BRANCH_COUNT}"
+          [[ "$BRANCH_COUNT" -gt 0 ]] && cat /tmp/all-branches.txt || true
+
+          BRANCHES_JSON=$(jq -R -s -c 'split("\n") | map(select(length > 0))' < /tmp/all-branches.txt)
+          echo "branches=${BRANCHES_JSON}" >> "$GITHUB_OUTPUT"
+
+          # Open PRs with the label (label-removal targets).
+          # When `branch` input is given, narrow to PRs whose head ref matches.
+          : > /tmp/open-prs.txt
+          if [[ -n "$INPUT_BRANCH" ]]; then
+            SANITIZED_INPUT=$(sanitize "$INPUT_BRANCH")
+            gh pr list --repo "$REPO" --label "$LABEL" --state open --limit 1000 \
+              --json number,headRefName > /tmp/open-pr-list.json 2>/dev/null || echo '[]' > /tmp/open-pr-list.json
+            while IFS=$'\t' read -r pr_num head_ref; do
+              [[ -z "$pr_num" ]] && continue
+              if [[ "$head_ref" == "$INPUT_BRANCH" ]] || [[ "$(sanitize "$head_ref")" == "$SANITIZED_INPUT" ]]; then
+                echo "$pr_num" >> /tmp/open-prs.txt
+              fi
+            done < <(jq -r '.[] | "\(.number)\t\(.headRefName)"' /tmp/open-pr-list.json)
+          else
+            gh pr list --repo "$REPO" --label "$LABEL" --state open --limit 1000 \
+              --json number --jq '.[].number' > /tmp/open-prs.txt 2>/dev/null || true
+          fi
+          PR_NUMBERS_JSON=$(jq -R -s -c 'split("\n") | map(select(length > 0) | tonumber)' < /tmp/open-prs.txt)
+          echo "pr-numbers=${PR_NUMBERS_JSON}" >> "$GITHUB_OUTPUT"
+
+  cleanup-each:
+    name: Cleanup
+    needs: collect
+    if: needs.collect.outputs.branches != '[]' && needs.collect.outputs.branches != ''
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.collect.outputs.branches) }}
+    uses: ./.github/workflows/reusable-cleanup-docker-snapshots.yaml
+    with:
+      branch: ${{ matrix.branch }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
+
+  remove-labels:
+    name: Remove snapshot/docker labels from open PRs
+    needs: [collect, cleanup-each]
+    if: |
+      always() &&
+      needs.collect.result == 'success' &&
+      needs.collect.outputs.pr-numbers != '[]' &&
+      needs.collect.outputs.pr-numbers != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      removed: ${{ steps.remove.outputs.removed }}
+      failed: ${{ steps.remove.outputs.failed }}
+    steps:
+      - name: Remove labels
+        id: remove
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBERS: ${{ needs.collect.outputs.pr-numbers }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          REMOVED=0
+          FAILED=0
+          while IFS= read -r pr; do
+            [[ -z "$pr" ]] && continue
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "[DRY RUN] Would remove snapshot/docker label from PR #${pr}"
+              ((REMOVED++)) || true
+            else
+              if gh pr edit "$pr" --remove-label "snapshot/docker"; then
+                echo "Removed label from PR #${pr}"
+                ((REMOVED++)) || true
+              else
+                echo "::warning::Failed to remove label from PR #${pr}"
+                ((FAILED++)) || true
+              fi
+            fi
+          done < <(echo "$PR_NUMBERS" | jq -r '.[]')
+          echo "removed=${REMOVED}" >> "$GITHUB_OUTPUT"
+          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+
+  summary:
+    name: Summary
+    needs: [collect, cleanup-each, remove-labels]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate
+        env:
+          BRANCHES: ${{ needs.collect.outputs.branches }}
+          PR_NUMBERS: ${{ needs.collect.outputs.pr-numbers }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          LABELS_REMOVED: ${{ needs.remove-labels.outputs.removed || '0' }}
+          LABELS_FAILED: ${{ needs.remove-labels.outputs.failed || '0' }}
+        run: |
+          BRANCH_COUNT=$(echo "${BRANCHES:-[]}" | jq 'length')
+          PR_COUNT=$(echo "${PR_NUMBERS:-[]}" | jq 'length')
+          {
+            echo "## Cleanup all docker snapshots"
+            echo
+            echo "| Key | Value |"
+            echo "| --- | --- |"
+            echo "| Input branch | \`${INPUT_BRANCH:-<all>}\` |"
+            echo "| Dry run | ${DRY_RUN} |"
+            echo "| Branches processed | ${BRANCH_COUNT} |"
+            echo "| Open PRs with label | ${PR_COUNT} |"
+            echo "| Labels removed | ${LABELS_REMOVED} |"
+            echo "| Label removal failed | ${LABELS_FAILED} |"
+            echo
+            echo "Per-branch results: see the \`Cleanup\` matrix jobs."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-snapshot.yaml
+++ b/.github/workflows/docker-snapshot.yaml
@@ -1,0 +1,219 @@
+name: Docker snapshot
+
+# Add the `snapshot/docker` label to a PR to publish the mcp-server container
+# image to ghcr.io. Removing the label or closing the PR cleans up the
+# associated snapshot images automatically.
+
+on:
+  pull_request:
+    types: [labeled, synchronize, unlabeled, closed]
+
+concurrency:
+  group: snapshot-docker-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ── snapshot/docker label added / push to a labeled PR → publish ──
+  prepare:
+    name: Prepare snapshot tags
+    runs-on: ubuntu-latest
+    # Skip fork PRs: pull_request from a fork runs with a read-only
+    # GITHUB_TOKEN and no secrets, so docker login / push would fail. Limit
+    # the workflow to PRs from the same repository to avoid noise.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'snapshot/docker') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'snapshot/docker'))
+      )
+    outputs:
+      sanitized-branch: ${{ steps.branch.outputs.sanitized-branch }}
+      moving-tag: ${{ steps.branch.outputs.moving-tag }}
+      immutable-tag: ${{ steps.tags.outputs.immutable-tag }}
+      tags-csv: ${{ steps.tags.outputs.tags-csv }}
+      short-sha: ${{ steps.tags.outputs.short-sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+
+      - name: Sanitize branch name
+        id: branch
+        uses: ./.github/actions/sanitize-snapshot-branch
+        with:
+          branch: ${{ github.head_ref }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          SANITIZED_BRANCH: ${{ steps.branch.outputs.sanitized-branch }}
+          MOVING_TAG: ${{ steps.branch.outputs.moving-tag }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          IMMUTABLE_TAG="${SANITIZED_BRANCH}-${TIMESTAMP}-${SHORT_SHA}"
+          {
+            echo "immutable-tag=${IMMUTABLE_TAG}"
+            echo "tags-csv=${IMMUTABLE_TAG},${MOVING_TAG}"
+            echo "short-sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Build and publish image
+    needs: prepare
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-publish-image.yaml
+    with:
+      tags: ${{ needs.prepare.outputs.tags-csv }}
+      push: true
+      # Build the exact PR HEAD, not the pull_request merge commit, so the
+      # short-sha embedded in the immutable tag matches the built content.
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit
+
+  comment-publish:
+    name: Comment on PR (publish)
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IMMUTABLE_TAG: ${{ needs.prepare.outputs.immutable-tag }}
+          MOVING_TAG: ${{ needs.prepare.outputs.moving-tag }}
+          SHORT_SHA: ${{ needs.prepare.outputs.short-sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/kintone/mcp-server"
+          BODY=$(cat <<EOF
+          <!-- snapshot-docker -->
+          ### mcp-server snapshot image published
+
+          | Key | Value |
+          | --- | --- |
+          | Image | \`${IMAGE}\` |
+          | Immutable tag | \`${IMMUTABLE_TAG}\` |
+          | Moving tag | \`${MOVING_TAG}\` |
+          | Commit | ${SHORT_SHA} |
+
+          \`\`\`bash
+          docker pull ${IMAGE}:${MOVING_TAG}
+          \`\`\`
+
+          Pin a specific build:
+          \`\`\`bash
+          docker pull ${IMAGE}:${IMMUTABLE_TAG}
+          \`\`\`
+          EOF
+          )
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq 'map(select(.body | contains("<!-- snapshot-docker -->"))) | .[0].id // empty')
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="${BODY}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          fi
+
+      - name: Summary
+        env:
+          IMMUTABLE_TAG: ${{ needs.prepare.outputs.immutable-tag }}
+          MOVING_TAG: ${{ needs.prepare.outputs.moving-tag }}
+        run: |
+          IMAGE="ghcr.io/kintone/mcp-server"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Docker Snapshot Published
+
+          | Key | Value |
+          | --- | --- |
+          | Image | \`${IMAGE}\` |
+          | Immutable tag | \`${IMMUTABLE_TAG}\` |
+          | Moving tag | \`${MOVING_TAG}\` |
+
+          ### Pull
+          \`\`\`bash
+          docker pull ${IMAGE}:${MOVING_TAG}
+          \`\`\`
+          EOF
+
+  # ── label removed / labeled PR closed → cleanup ──
+  cleanup:
+    name: Cleanup branch snapshots
+    # Same fork-PR guard as `prepare` above.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'unlabeled' && github.event.label.name == 'snapshot/docker') ||
+        (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'snapshot/docker'))
+      )
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-cleanup-docker-snapshots.yaml
+    with:
+      branch: ${{ github.head_ref }}
+    secrets: inherit
+
+  comment-cleanup:
+    name: Comment on PR (cleanup)
+    needs: cleanup
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DELETED_COUNT: ${{ needs.cleanup.outputs.deleted-count }}
+          MATCHED_COUNT: ${{ needs.cleanup.outputs.matched-count }}
+          MOVING_TAG: ${{ needs.cleanup.outputs.moving-tag }}
+        run: |
+          set -euo pipefail
+          BODY=$(cat <<EOF
+          <!-- snapshot-docker -->
+          ### mcp-server snapshot cleaned up
+
+          | Key | Value |
+          | --- | --- |
+          | Moving tag removed | \`${MOVING_TAG}\` |
+          | Versions matched | ${MATCHED_COUNT} |
+          | Versions deleted | ${DELETED_COUNT} |
+          EOF
+          )
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq 'map(select(.body | contains("<!-- snapshot-docker -->"))) | .[0].id // empty')
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="${BODY}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          fi
+
+  # ── On close, drop the label too ──
+  # Only remove the label after a successful cleanup; otherwise leave it as a
+  # trigger for re-runs.
+  remove-label:
+    name: Remove snapshot/docker label
+    needs: cleanup
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove label
+        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label "snapshot/docker"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/reusable-cleanup-docker-snapshots.yaml
+++ b/.github/workflows/reusable-cleanup-docker-snapshots.yaml
@@ -1,0 +1,164 @@
+name: Reusable - Cleanup docker snapshot images
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Raw branch name. Deletes all snapshot images for this branch."
+        required: true
+        type: string
+      dry-run:
+        description: "List versions but do not delete"
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      deleted-count:
+        description: "Number of versions deleted"
+        value: ${{ jobs.cleanup.outputs.deleted-count }}
+      failed-count:
+        description: "Number of versions that failed to delete"
+        value: ${{ jobs.cleanup.outputs.failed-count }}
+      matched-count:
+        description: "Number of versions matched"
+        value: ${{ jobs.cleanup.outputs.matched-count }}
+      moving-tag:
+        description: "Moving tag for the branch"
+        value: ${{ jobs.cleanup.outputs.moving-tag }}
+
+jobs:
+  cleanup:
+    name: Cleanup branch snapshots
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      deleted-count: ${{ steps.delete.outputs.deleted-count || '0' }}
+      failed-count: ${{ steps.delete.outputs.failed-count || '0' }}
+      matched-count: ${{ steps.list.outputs.count || '0' }}
+      moving-tag: ${{ steps.branch.outputs.moving-tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+
+      - name: Sanitize branch name
+        id: branch
+        uses: ./.github/actions/sanitize-snapshot-branch
+        with:
+          branch: ${{ inputs.branch }}
+
+      - name: List snapshot versions
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MOVING_TAG: ${{ steps.branch.outputs.moving-tag }}
+          SANITIZED_BRANCH: ${{ steps.branch.outputs.sanitized-branch }}
+        run: |
+          set -euo pipefail
+          ORG="kintone"
+          PACKAGE_NAME="mcp-server"
+
+          # immutable tag: <sanitized-branch>-<14 digit ts>-<7 hex sha>.
+          # Use a structural regex to avoid sweeping `feat-foo-bar-...` when
+          # the cleanup target is `feat-foo`.
+          gh api --paginate "/orgs/${ORG}/packages/container/${PACKAGE_NAME}/versions" \
+            --jq '.[] | "\(.id)\t\(.metadata.container.tags | join(","))"' \
+            | awk -F'\t' -v moving="$MOVING_TAG" -v branch="$SANITIZED_BRANCH" '
+              {
+                n = split($2, tags, ",")
+                for (i = 1; i <= n; i++) {
+                  if (tags[i] == moving) { print; next }
+                  if (match(tags[i], "^" branch "-[0-9]{14}-[0-9a-f]{7}$")) { print; next }
+                }
+              }
+            ' > /tmp/target-versions.tsv || true
+
+          COUNT=$(wc -l < /tmp/target-versions.tsv | tr -d ' ')
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Found ${COUNT} version(s) matching moving=${MOVING_TAG} or immutable for branch=${SANITIZED_BRANCH}"
+          if [[ "$COUNT" -gt 0 ]]; then
+            cat /tmp/target-versions.tsv
+          fi
+
+      - name: Delete snapshot versions
+        if: steps.list.outputs.count != '0'
+        id: delete
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          ORG="kintone"
+          PACKAGE_NAME="mcp-server"
+          MAX_RETRIES=3
+          TOTAL=$(wc -l < /tmp/target-versions.tsv | tr -d ' ')
+          CURRENT=0
+          DELETED_COUNT=0
+          FAILED_COUNT=0
+
+          while IFS=$'\t' read -r version_id tags; do
+            ((CURRENT++)) || true
+            echo "::group::[${CURRENT}/${TOTAL}] id=${version_id} tags=${tags}"
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "[DRY RUN] Would delete id=${version_id} (tags: ${tags})"
+              ((DELETED_COUNT++)) || true
+            else
+              success=false
+              for attempt in $(seq 1 "$MAX_RETRIES"); do
+                if gh api -X DELETE "/orgs/${ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" --silent 2>/dev/null; then
+                  echo "Deleted id=${version_id}"
+                  success=true
+                  break
+                fi
+                echo "Attempt ${attempt}/${MAX_RETRIES} failed"
+                sleep 1
+              done
+              if [[ "$success" == "true" ]]; then
+                ((DELETED_COUNT++)) || true
+              else
+                echo "::warning::Failed to delete id=${version_id} (tags: ${tags}) after ${MAX_RETRIES} attempts"
+                ((FAILED_COUNT++)) || true
+              fi
+            fi
+
+            echo "::endgroup::"
+          done < /tmp/target-versions.tsv
+
+          echo "deleted-count=${DELETED_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "failed-count=${FAILED_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        if: always()
+        env:
+          BRANCH_NAME: ${{ inputs.branch }}
+          MOVING_TAG: ${{ steps.branch.outputs.moving-tag }}
+          IMMUTABLE_PREFIX: ${{ steps.branch.outputs.immutable-prefix }}
+          DELETED_COUNT: ${{ steps.delete.outputs.deleted-count || '0' }}
+          FAILED_COUNT: ${{ steps.delete.outputs.failed-count || '0' }}
+          MATCHED_COUNT: ${{ steps.list.outputs.count || '0' }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Docker Branch Snapshot Cleanup
+
+          | Key | Value |
+          | --- | --- |
+          | Branch | \`${BRANCH_NAME}\` |
+          | Moving tag | \`${MOVING_TAG}\` |
+          | Immutable prefix | \`${IMMUTABLE_PREFIX}\` |
+          | Versions matched | ${MATCHED_COUNT} |
+          | Versions deleted | ${DELETED_COUNT} |
+          | Versions failed | ${FAILED_COUNT} |
+          | Dry run | ${DRY_RUN} |
+          EOF
+
+      - name: Fail if any deletions failed
+        if: steps.delete.outputs.failed-count != '0' && steps.delete.outputs.failed-count != ''
+        env:
+          FAILED_COUNT: ${{ steps.delete.outputs.failed-count }}
+        run: |
+          echo "::error::${FAILED_COUNT} version(s) failed to delete"
+          exit 1

--- a/.github/workflows/reusable-publish-image.yaml
+++ b/.github/workflows/reusable-publish-image.yaml
@@ -11,6 +11,15 @@ on:
         required: false
         type: boolean
         default: true
+      ref:
+        description: >
+          Git ref (branch, tag, or SHA) to build. Defaults to the event's
+          default checkout (GITHUB_SHA). On pull_request events that is the
+          merge commit, so pass the PR head SHA explicitly to build the exact
+          PR HEAD.
+        required: false
+        type: string
+        default: ""
 
 defaults:
   run:
@@ -51,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ Dockerコンテナイメージ
 docker build -f ./docker/Dockerfile .
 ```
 
+PRから検証用イメージを ghcr.io に publish する場合は [docs/dev/snapshot-publish.md](docs/dev/snapshot-publish.md) を参照してください。
+
 MCPBファイル
 
 ```shell

--- a/docs/dev/snapshot-publish.md
+++ b/docs/dev/snapshot-publish.md
@@ -1,0 +1,192 @@
+# Docker snapshot images
+
+PR-stage container images for verifying mcp-server changes in environments outside CI before merging.
+
+| Method                                                     | Trigger             | Cleanup                                    |
+| ---------------------------------------------------------- | ------------------- | ------------------------------------------ |
+| [Label-driven (`snapshot/docker`)](#label-driven-snapshot) | PR label            | Automatic on label removal / PR close      |
+| [Manual dispatch (legacy)](#manual-dispatch-legacy)        | `workflow_dispatch` | Manual / via [bulk cleanup](#bulk-cleanup) |
+
+---
+
+## Label-driven snapshot
+
+Add the `snapshot/docker` label to a PR to publish a container image of the
+PR's HEAD to `ghcr.io/kintone/mcp-server`. Pushing additional commits to the
+labeled PR refreshes the image. Removing the label or closing the PR cleans up
+the published images automatically.
+
+Implementation:
+
+- [`.github/workflows/docker-snapshot.yaml`](../../.github/workflows/docker-snapshot.yaml) — publish + cleanup entrypoint
+- [`.github/workflows/reusable-cleanup-docker-snapshots.yaml`](../../.github/workflows/reusable-cleanup-docker-snapshots.yaml) — per-branch cleanup
+- [`.github/workflows/cleanup-all-docker-snapshots.yaml`](../../.github/workflows/cleanup-all-docker-snapshots.yaml) — bulk cleanup with branch filter and dry-run
+- [`.github/actions/sanitize-snapshot-branch/`](../../.github/actions/sanitize-snapshot-branch/action.yaml) — branch-name sanitiser
+- [`.github/workflows/reusable-publish-image.yaml`](../../.github/workflows/reusable-publish-image.yaml) — image build / push (existing)
+
+### Usage
+
+1. Add the `snapshot/docker` label to a PR.
+2. The workflow builds the container image and pushes it to GHCR.
+3. A PR comment is posted (and updated on subsequent pushes) with the image,
+   tags, and a `docker pull` command.
+
+```text
+### mcp-server snapshot image published
+
+| Key | Value |
+| --- | --- |
+| Image | `ghcr.io/kintone/mcp-server` |
+| Immutable tag | `feat-new-tool-20260501123045-abc1234` |
+| Moving tag | `snapshot-feat-new-tool` |
+| Commit | abc1234 |
+```
+
+Pull the latest build for the branch:
+
+```bash
+docker pull ghcr.io/kintone/mcp-server:snapshot-feat-new-tool
+```
+
+Pin a specific build:
+
+```bash
+docker pull ghcr.io/kintone/mcp-server:feat-new-tool-20260501123045-abc1234
+```
+
+### Cleanup
+
+Cleanup runs automatically when:
+
+- The `snapshot/docker` label is removed from the PR.
+- The PR is closed or merged (cleanup then strips the label).
+
+The cleanup deletes every package version whose tags include either the moving
+tag (`snapshot-<branch>`, exact match) or a tag structurally matching the
+immutable form `<branch>-<YYYYMMDDHHMMSS>-<short-sha>`. A plain `<branch>-`
+prefix is not enough, so a sibling branch such as `feat-foo-bar` is not swept
+when cleaning up `feat-foo`.
+
+### Tag scheme
+
+| Type      | Format                                            | Example                                |
+| --------- | ------------------------------------------------- | -------------------------------------- |
+| Immutable | `{sanitized-branch}-{YYYYMMDDHHMMSS}-{short-sha}` | `feat-new-tool-20260501123045-abc1234` |
+| Moving    | `snapshot-{sanitized-branch}`                     | `snapshot-feat-new-tool`               |
+
+Branch sanitisation:
+
+1. Replace `[^a-zA-Z0-9-]` with `-` (`/`, `_`, etc.).
+2. Collapse repeated `-`.
+3. Trim leading / trailing `-`.
+4. Truncate to 50 characters.
+
+Example: `feat/new-tool_v2` → `feat-new-tool-v2`.
+
+### Workflow detail
+
+**Publish:**
+
+```
+PR labeled with snapshot/docker (or push to a labeled PR)
+       │
+       ▼
+  sanitise branch → compute tags
+       │
+       ▼
+  reusable-publish-image (push immutable + moving tags together)
+       │
+       ▼
+  PR comment created / updated
+```
+
+- Concurrent runs on the same PR cancel earlier executions.
+- The PR comment is identified by the HTML marker `<!-- snapshot-docker -->`
+  and updated in place.
+
+**Cleanup:**
+
+```
+Label removed (or labeled PR closed)
+       │
+       ▼
+  list ghcr versions, filter by exact moving tag or immutable-form match
+       │
+       ▼
+  delete each version (up to 3 retries)
+       │
+       ▼
+  PR comment updated
+```
+
+When the PR is closed, the `snapshot/docker` label is removed after a
+successful cleanup.
+
+---
+
+## Bulk cleanup
+
+[`cleanup-all-docker-snapshots.yaml`](../../.github/workflows/cleanup-all-docker-snapshots.yaml)
+can be invoked from the Actions tab to remove leftover snapshot images, either
+for a specific branch or every branch that ever had a snapshot.
+
+| Input     | Required | Default | Description                                                                                                        |
+| --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `branch`  | No       | `""`    | If set, only this branch is cleaned. Empty means every branch found in moving tags or labeled PRs.                 |
+| `dry-run` | No       | `true`  | When true, lists what would be deleted without performing any destructive action. **Defaults to true** for safety. |
+
+Recommended workflow: run with `dry-run: true` first to verify the target
+list, then re-run with `dry-run: false` to delete.
+
+The job also strips the `snapshot/docker` label from open PRs that still carry
+it (or lists them only when `dry-run: true`).
+
+---
+
+## Manual dispatch (legacy)
+
+[`publish-snapshot-image.yaml`](../../.github/workflows/publish-snapshot-image.yaml)
+is the original `workflow_dispatch` flow. Prefer the label-driven workflow
+above; this one stays for compatibility and edge cases (e.g. publishing from a
+branch without a PR). Cleanup is **not** automatic — use the [bulk
+cleanup](#bulk-cleanup) workflow.
+
+---
+
+## Operational notes
+
+- **Avoid mixing the legacy and label-driven flows on the same branch.** The
+  cleanup deletes versions whose tag exactly matches the moving tag
+  (`snapshot-<branch>`) or structurally matches the immutable form
+  (`<branch>-<YYYYMMDDHHMMSS>-<short-sha>`). The legacy `workflow_dispatch`
+  flow takes a free-form tag input, so an image it published on the same branch
+  is only swept if that tag happens to match one of these forms. Once a branch
+  is on the label-driven flow, do not also publish via `workflow_dispatch` for
+  it.
+- The `snapshot/docker` label must exist in the repository before the workflow
+  can be triggered. Create it once via the Labels settings if it is missing.
+- Branch names longer than 50 characters get truncated; refer to the PR
+  comment for the exact tag in use.
+- **Fork PRs are skipped.** `pull_request` from a fork runs with a read-only
+  `GITHUB_TOKEN` and no access to secrets, so the workflow would fail at the
+  registry login or push step. The publish and cleanup jobs are gated on the
+  PR head being from the same repository.
+- **Snapshots are not releases.** They are dev-only artifacts built from a PR
+  HEAD, may contain unstable or experimental code, and are deleted when the
+  PR is closed. Do not use them in production. Stable releases come from the
+  release workflow with semver tags.
+- **Sensitive branch names become public tags.** A branch name like
+  `fix-CVE-2025-XXXX` would appear in the immutable tag pushed to the public
+  registry. Don't add `snapshot/docker` to PRs related to embargoed
+  vulnerabilities until they are disclosed.
+
+### First-time setup
+
+The first push creates the `mcp-server` container package on GHCR. By default
+it is private. To allow anonymous pulls (which is the typical usage), a
+maintainer needs to flip the visibility to public once:
+
+> Repository → Packages → `mcp-server` → Package settings → Change package
+> visibility → Public
+
+This step is only needed once; subsequent pushes inherit the visibility.


### PR DESCRIPTION
## Why

The container image can only be published manually today (`publish-snapshot-image.yaml`, `workflow_dispatch`), and nothing cleans the images up — they linger on ghcr.io after a PR is closed. This adds an opt-in, label-driven snapshot flow so a reviewer can pull a verification image built from a PR and have it removed automatically when the PR is done.

## What

- Adding the `snapshot/docker` label to a PR builds and pushes a container image to ghcr.io with an immutable tag (`<branch>-<YYYYMMDDHHMMSS>-<short-sha>`) and a moving tag (`snapshot-<branch>`). Pushes to a labeled PR update both, and a PR comment records the tags and the pull command.
- Removing the label or closing/merging the PR cleans up the matching versions (moving tag exact match + immutable-form structural match) and strips the label.
- `cleanup-all-docker-snapshots.yaml` (`workflow_dispatch`, dry-run by default) for bulk or branch-targeted cleanup of leftover snapshots.
- A `sanitize-snapshot-branch` composite action and a `reusable-cleanup-docker-snapshots.yaml`.
- Fork PRs are gated out (same-repo only): a `pull_request` from a fork runs with a read-only `GITHUB_TOKEN` and no secrets, so it is skipped to avoid noise.
- `reusable-publish-image.yaml` gains an optional `ref` input (default keeps the current behaviour). The snapshot flow passes the PR head SHA so the built image matches the SHA embedded in the immutable tag, instead of building the `pull_request` merge commit.
- Docs in `docs/dev/snapshot-publish.md` and a note in `CONTRIBUTING.md`.

## How to test

- GitHub Actions cannot be exercised locally; validated by reviewing the workflow structure.
- Real verification on a PR: add `snapshot/docker` → confirm the image is published and the PR comment appears; remove the label / close the PR → confirm the versions are deleted and the label is stripped.
- Run `cleanup-all-docker-snapshots.yaml` with `dry-run: true` first to preview targets before a real bulk cleanup.

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.