### PR TITLE
ci: set GH_REPO so snapshot PR comments work without a checkout

### DIFF
--- a/.github/workflows/docker-snapshot.yaml
+++ b/.github/workflows/docker-snapshot.yaml
@@ -85,6 +85,7 @@ jobs:
       - name: Comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           IMMUTABLE_TAG: ${{ needs.prepare.outputs.immutable-tag }}
           MOVING_TAG: ${{ needs.prepare.outputs.moving-tag }}
@@ -173,6 +174,7 @@ jobs:
       - name: Comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           DELETED_COUNT: ${{ needs.cleanup.outputs.deleted-count }}
           MATCHED_COUNT: ${{ needs.cleanup.outputs.matched-count }}


### PR DESCRIPTION
## What

The `Docker snapshot` workflow's comment jobs (`comment-publish`, `comment-cleanup`) run `gh pr comment` on a runner that has **no repository checkout**. Without a git remote in the working directory, `gh` falls back to inferring the repo from git and fails:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This bites the **first** publish on a PR: there is no existing snapshot comment to PATCH, so the workflow hits the `else` branch (`gh pr comment "$PR_NUMBER" --body ...`), which needs repo context and dies. The image publish itself succeeds; only the comment step fails.

Observed on PR #477 (a Renovate PR that received the `snapshot/docker` label): https://github.com/kintone/mcp-server/actions/runs/27670154681/job/81832918115

## Fix

Add `GH_REPO: ${{ github.repository }}` to the env of both comment jobs so `gh` resolves the repository from the environment instead of git — the same approach the existing `remove-label` job already uses. No checkout step is needed.

Follow-up to #476.