### PR TITLE
fix: mask credentials in proxy URL error message

### DIFF
--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -267,7 +267,22 @@ describe("getKintoneClient", () => {
       };
 
       expect(() => getKintoneClient(config)).toThrow(
-        "Invalid HTTPS proxy URL: invalid-url. Invalid URL",
+        "Invalid HTTPS proxy URL: [invalid proxy URL]. Invalid URL",
+      );
+    });
+
+    it("should mask credentials in error message when proxy URL contains username and password", () => {
+      mockHttpsProxyAgent.mockImplementationOnce(() => {
+        throw new Error("Connection refused");
+      });
+
+      const config: KintoneClientConfig = {
+        ...mockKintoneConfig,
+        HTTPS_PROXY: "http://user:pass@proxy.example.com:8080",
+      };
+
+      expect(() => getKintoneClient(config)).toThrow(
+        "Invalid HTTPS proxy URL: http://proxy.example.com:8080/. Connection refused",
       );
     });
   });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -78,6 +78,17 @@ const buildBasicAuthParam = (options: {
     : {};
 };
 
+const maskProxyUrl = (proxyUrl: string): string => {
+  try {
+    const url = new URL(proxyUrl);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return "[invalid proxy URL]";
+  }
+};
+
 const buildHttpsAgent = (options: {
   proxy?: string;
   pfxFilePath?: string;
@@ -103,7 +114,7 @@ const buildHttpsAgent = (options: {
       return new HttpsProxyAgent(options.proxy, agentOptions);
     } catch (error) {
       throw new Error(
-        `Invalid HTTPS proxy URL: ${options.proxy}. ${error instanceof Error ? error.message : String(error)}`,
+        `Invalid HTTPS proxy URL: ${maskProxyUrl(options.proxy)}. ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }


### PR DESCRIPTION
## Why

When `HTTPS_PROXY` is set to a URL containing credentials (e.g., `http://user:pass@host:port`), a proxy initialization failure surfaces the full URL in the error message, exposing credentials in plain text in logs.

## What

Added a `maskProxyUrl()` helper in `src/client/index.ts` that strips username/password from a proxy URL before using it in error messages.

- Parses the URL with `new URL()` and clears `username` / `password` before converting back to string
- Falls back to `[invalid proxy URL]` when the URL cannot be parsed at all

## How to test

Run the test suite:

```bash
pnpm test
```

All tests pass, including new test cases for credential masking behavior.

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.