### PR TITLE
feat: add kintone-delete-space tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-add-space-from-template` | テンプレートからスペースを作成         |
 | `kintone-update-space`            | スペースの設定を更新                   |
 | `kintone-get-space`               | スペースの情報を取得                   |
+| `kintone-delete-space`            | スペースを削除                         |
 
 ## ドキュメント
 

--- a/README_en.md
+++ b/README_en.md
@@ -227,6 +227,7 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-add-space-from-template` | Create a new kintone space from a space template   |
 | `kintone-update-space`            | Update space settings                              |
 | `kintone-get-space`               | Get space information and portal settings          |
+| `kintone-delete-space`            | Delete a space                                     |
 
 ## Documentation
 

--- a/manifest.json
+++ b/manifest.json
@@ -147,6 +147,10 @@
     {
       "name": "kintone-update-space",
       "description": "Update settings of a kintone space via the Space REST API (PUT /k/v1/space.json). Modifies space configuration such as name, privacy, member lock, multi-thread mode, portal widget visibility, and who may create apps (EVERYONE vs ADMIN). Only fields included in the request are updated; omitted fields keep their existing values. useMultiThread is applied only when true (single-thread to multi-thread switch); passing false has no effect. Requires space administrator privileges on the target space. The API returns an empty body on success."
+    },
+    {
+      "name": "kintone-delete-space",
+      "description": "Delete a kintone space via the Space REST API (DELETE /k/v1/space.json). Destructive and irreversible: permanently removes the target space along with all of its threads, comments, and the apps and records that belong to the space. Requires space administrator privileges on the target space. The deletion is applied immediately to the production environment (no deploy step) and cannot be undone from this tool. The API returns an empty body on success."
     }
   ],
   "tools_generated": true,

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -40,6 +40,7 @@ export const createMockClient = (): KintoneRestAPIClient =>
       addSpaceFromTemplate: vi.fn(),
       updateSpace: vi.fn(),
       getSpace: vi.fn(),
+      deleteSpace: vi.fn(),
     },
     search: vi.fn(),
   }) as unknown as KintoneRestAPIClient;

--- a/src/server/tool-filters.ts
+++ b/src/server/tool-filters.ts
@@ -16,6 +16,7 @@ const filterRules: FilterRule[] = [
       "kintone-search",
       "kintone-update-space",
       "kintone-get-space",
+      "kintone-delete-space",
     ],
   },
 ];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -25,6 +25,7 @@ import { addSpaceFromTemplate } from "./kintone/space/add-space-from-template.js
 import { getSpace } from "./kintone/space/get-space.js";
 import { search } from "./kintone/search/search.js";
 import { updateSpace } from "./kintone/space/update-space.js";
+import { deleteSpace } from "./kintone/space/delete-space.js";
 
 export { createToolCallback } from "./factory.js";
 export const tools: Array<Tool<any, any>> = [
@@ -54,4 +55,5 @@ export const tools: Array<Tool<any, any>> = [
   getSpace,
   search,
   updateSpace,
+  deleteSpace,
 ] as const;

--- a/src/tools/kintone/space/__tests__/delete-space.test.ts
+++ b/src/tools/kintone/space/__tests__/delete-space.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import { deleteSpace } from "../delete-space.js";
+import { createMockClient } from "../../../../__tests__/utils.js";
+
+const mockDeleteSpace = vi.fn();
+
+describe("delete-space tool", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      KINTONE_BASE_URL: "https://example.cybozu.com",
+      KINTONE_USERNAME: "testuser",
+      KINTONE_PASSWORD: "testpass",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("tool configuration", () => {
+    it("should have correct name", () => {
+      expect(deleteSpace.name).toBe("kintone-delete-space");
+    });
+
+    it("should have correct description", () => {
+      expect(deleteSpace.config.description).toBe(
+        "Delete a kintone space via the Space REST API (DELETE /k/v1/space.json). " +
+          "Destructive and irreversible: permanently removes the target space along with all of its threads, comments, and the apps and records that belong to the space. " +
+          "Requires space administrator privileges on the target space. " +
+          "The deletion is applied immediately to the production environment (no deploy step) and cannot be undone from this tool. " +
+          "The API returns an empty body on success.",
+      );
+    });
+
+    it("should have valid input schema", () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const schema = z.object(deleteSpace.config.inputSchema!);
+
+      expect(() => schema.parse({ id: "1" })).not.toThrow();
+      expect(() => schema.parse({})).toThrow();
+      expect(() => schema.parse({ id: 1 })).toThrow();
+    });
+  });
+
+  describe("callback function", () => {
+    it("should call deleteSpace and return empty content", async () => {
+      mockDeleteSpace.mockResolvedValueOnce({});
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const input = z.object(deleteSpace.config.inputSchema!).parse({
+        id: "99",
+      });
+
+      const mockClient = createMockClient();
+      mockClient.space.deleteSpace = mockDeleteSpace;
+
+      const result = await deleteSpace.callback(input, {
+        client: mockClient,
+      });
+
+      expect(mockDeleteSpace).toHaveBeenCalledWith({ id: "99" });
+      expect(result.structuredContent).toEqual({});
+      expect(result.content).toEqual([]);
+    });
+  });
+});

--- a/src/tools/kintone/space/__tests__/delete-space.test.ts
+++ b/src/tools/kintone/space/__tests__/delete-space.test.ts
@@ -67,5 +67,22 @@ describe("delete-space tool", () => {
       expect(result.structuredContent).toEqual({});
       expect(result.content).toEqual([]);
     });
+
+    it("should propagate errors from the API", async () => {
+      const mockError = new Error("API Error: Space not found");
+      mockDeleteSpace.mockRejectedValueOnce(mockError);
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const input = z.object(deleteSpace.config.inputSchema!).parse({
+        id: "999",
+      });
+
+      const mockClient = createMockClient();
+      mockClient.space.deleteSpace = mockDeleteSpace;
+
+      await expect(
+        deleteSpace.callback(input, { client: mockClient }),
+      ).rejects.toThrow("API Error: Space not found");
+    });
   });
 });

--- a/src/tools/kintone/space/delete-space.ts
+++ b/src/tools/kintone/space/delete-space.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { createTool } from "../../factory.js";
+import type { KintoneToolCallback } from "../../types/tool.js";
+
+const inputSchema = {
+  id: z
+    .string()
+    .describe(
+      "Space ID as returned by Kintone (numeric string). Same value as in space URLs and other Space APIs.",
+    ),
+};
+
+const outputSchema = {};
+
+const toolName = "kintone-delete-space";
+const toolConfig = {
+  title: "Delete Space",
+  description:
+    "Delete a kintone space via the Space REST API (DELETE /k/v1/space.json). " +
+    "Destructive and irreversible: permanently removes the target space along with all of its threads, comments, and the apps and records that belong to the space. " +
+    "Requires space administrator privileges on the target space. " +
+    "The deletion is applied immediately to the production environment (no deploy step) and cannot be undone from this tool. " +
+    "The API returns an empty body on success.",
+  inputSchema,
+  outputSchema,
+};
+const callback: KintoneToolCallback<typeof inputSchema> = async (
+  { id },
+  { client },
+) => {
+  await client.space.deleteSpace({ id });
+
+  return {
+    structuredContent: {},
+    content: [],
+  };
+};
+
+export const deleteSpace = createTool(toolName, toolConfig, callback);


### PR DESCRIPTION
## Why

We already have tools to create and update spaces, but there was no way to **delete** one through the kintone MCP. The Space REST API supports deletion (`DELETE /k/v1/space.json`), so this fills that gap and rounds out the space lifecycle (create → update → delete).

Since deleting a space is destructive and irreversible—it removes the space along with all of its threads, comments, and the apps and records inside it—this tool requires space administrator privileges. Like the other space-management tools, it is **disabled when authenticating with an API token** (the Space API doesn't work with API tokens anyway), so it won't show up in that setup.

## What

- **Add `kintone-delete-space`**: takes a single space `id` (numeric string), calls `KintoneRestAPIClient.space.deleteSpace`, and returns an empty result to match the API's empty success response.
- The tool description spells out that the operation is destructive, irreversible, applied immediately to production (no deploy step), and cannot be undone from the tool.
- **Add unit tests** covering the tool name, description, input schema validation, and the mocked callback path.
- **Register the tool** in `src/tools/index.ts`, and **add it to `tool-filters`** so it's excluded under API token auth.
- **Update `manifest.json`, `README.md`, and `README_en.md`**.
- **Extend the test `createMockClient`** with a `space.deleteSpace` mock.

## How to test

1. Prepare a kintone environment where you have space administrator privileges, with `KINTONE_BASE_URL` and user credentials the Space API accepts (not API-token-only).
2. With **API token only**, confirm `kintone-delete-space` does not appear in the tool list, like the other excluded tools.
3. Create a throwaway space you don't mind losing, then call `kintone-delete-space` with its `id`.
4. Confirm the call succeeds (empty body) and that the space—and its threads, comments, apps, and records—are gone from kintone.
5. Try an invalid `id` (e.g. a non-existent space) and confirm the API error is surfaced.

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.