### PR TITLE
docs: correct license badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci][ci-badge]][ci-url]
 [![npm version][npm-badge]][npm-url]
-[![License: MIT][license-badge]][license-url]
+[![License: Apache 2.0][license-badge]][license-url]
 [![Install MCP Server][cursor-badge]][cursor-url]
 
 [ci-badge]: https://github.com/kintone/mcp-server/actions/workflows/ci.yaml/badge.svg

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 
 [![ci][ci-badge]][ci-url]
 [![npm version][npm-badge]][npm-url]
-[![License: MIT][license-badge]][license-url]
+[![License: Apache 2.0][license-badge]][license-url]
 [![Install MCP Server][cursor-badge]][cursor-url]
 
 [ci-badge]: https://github.com/kintone/mcp-server/actions/workflows/ci.yaml/badge.svg


### PR DESCRIPTION
## Why

The license badges in `README.md` and `README_en.md` display Apache 2.0, but their alt text still says `License: MIT`.

This creates inconsistent license information when the badge image is unavailable or read by assistive technologies.

## What

Update the license badge alt text in both README files to `License: Apache 2.0`.

The displayed badge image and its link remain unchanged.

## How to test

- Verify that the license badge alt text in `README.md` and `README_en.md` is `License: Apache 2.0`.
- Run `pnpm lint`.
- Run `pnpm test --run`.

## Checklist

- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
