### PR TITLE
fix: make config validation errors catchable and improve error messages

### DIFF
--- a/src/config/__tests__/parser/successful-parsing.test.ts
+++ b/src/config/__tests__/parser/successful-parsing.test.ts
@@ -164,6 +164,27 @@ describe("config - successful parsing", () => {
       expected: mockProvidedConfig,
     },
     {
+      name: "should treat empty username/password as not provided when API token is set",
+      env: {
+        KINTONE_BASE_URL: "https://example.cybozu.com",
+        KINTONE_USERNAME: "",
+        KINTONE_PASSWORD: "",
+        KINTONE_API_TOKEN: "abc123",
+      },
+      expected: {
+        KINTONE_BASE_URL: "https://example.cybozu.com",
+        KINTONE_API_TOKEN: "abc123",
+        KINTONE_USERNAME: undefined,
+        KINTONE_PASSWORD: undefined,
+        KINTONE_BASIC_AUTH_USERNAME: undefined,
+        KINTONE_BASIC_AUTH_PASSWORD: undefined,
+        HTTPS_PROXY: undefined,
+        KINTONE_PFX_FILE_PATH: undefined,
+        KINTONE_PFX_FILE_PASSWORD: undefined,
+        KINTONE_ATTACHMENTS_DIR: undefined,
+      },
+    },
+    {
       name: "should parse with API token instead of username/password",
       env: {
         KINTONE_BASE_URL: "https://example.cybozu.com",

--- a/src/config/__tests__/parser/validation-errors.test.ts
+++ b/src/config/__tests__/parser/validation-errors.test.ts
@@ -35,7 +35,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_BASE_URL: Invalid url",
+        "KINTONE_BASE_URL: Must be a valid URL (e.g., https://example.cybozu.com)",
       ],
     },
     {
@@ -46,7 +46,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_BASE_URL: Invalid url",
+        "KINTONE_BASE_URL: Required (e.g., https://example.cybozu.com)",
       ],
     },
     {
@@ -61,14 +61,14 @@ describe("config - validation errors", () => {
       ],
     },
     {
-      name: "should throw error when KINTONE_USERNAME is empty",
+      name: "should treat empty KINTONE_USERNAME as not provided",
       env: {
         ...mockProvidedConfig,
         KINTONE_USERNAME: "",
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_USERNAME: String must contain at least 1 character(s)",
+        "Either KINTONE_USERNAME/KINTONE_PASSWORD or KINTONE_API_TOKEN must be provided",
       ],
     },
     {
@@ -83,14 +83,14 @@ describe("config - validation errors", () => {
       ],
     },
     {
-      name: "should throw error when KINTONE_PASSWORD is empty",
+      name: "should treat empty KINTONE_PASSWORD as not provided",
       env: {
         ...mockProvidedConfig,
         KINTONE_PASSWORD: "",
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_PASSWORD: String must contain at least 1 character(s)",
+        "Either KINTONE_USERNAME/KINTONE_PASSWORD or KINTONE_API_TOKEN must be provided",
       ],
     },
     {
@@ -102,9 +102,8 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_BASE_URL: Invalid url",
-        "KINTONE_USERNAME: String must contain at least 1 character(s)",
-        "KINTONE_PASSWORD: String must contain at least 1 character(s)",
+        "KINTONE_BASE_URL: Must be a valid URL (e.g., https://example.cybozu.com)",
+        "Either KINTONE_USERNAME/KINTONE_PASSWORD or KINTONE_API_TOKEN must be provided",
       ],
     },
     {
@@ -124,7 +123,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "HTTPS_PROXY: Invalid proxy URL format",
+        "HTTPS_PROXY: Must be a valid URL (e.g., http://proxy.example.com:8080)",
       ],
     },
     {
@@ -135,7 +134,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "HTTPS_PROXY: Invalid proxy URL format",
+        "HTTPS_PROXY: Must be a valid URL (e.g., http://proxy.example.com:8080)",
       ],
     },
     {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,9 +4,17 @@ import { PACKAGE_NAME } from "./schema.js";
 import type {
   KintoneClientConfig,
   KintoneMcpServerConfig,
+  ParsedConfig,
 } from "./types/config.js";
 
-const config = parseKintoneMcpServerConfig();
+let cachedConfig: ParsedConfig | undefined;
+
+const getConfig = (): ParsedConfig => {
+  if (!cachedConfig) {
+    cachedConfig = parseKintoneMcpServerConfig();
+  }
+  return cachedConfig;
+};
 
 export const getMcpServerConfig = (): KintoneMcpServerConfig => {
   return {
@@ -16,6 +24,7 @@ export const getMcpServerConfig = (): KintoneMcpServerConfig => {
 };
 
 export const getKintoneClientConfig = (): KintoneClientConfig => {
+  const config = getConfig();
   return {
     KINTONE_BASE_URL: config.config.KINTONE_BASE_URL,
     KINTONE_USERNAME: config.config.KINTONE_USERNAME,
@@ -31,12 +40,14 @@ export const getKintoneClientConfig = (): KintoneClientConfig => {
 };
 
 export const getToolConditionConfig = () => {
+  const config = getConfig();
   return {
     isApiTokenAuth: config.isApiTokenAuth,
   };
 };
 
 export const getFileConfig = () => {
+  const config = getConfig();
   return {
     attachmentsDir: config.config.KINTONE_ATTACHMENTS_DIR,
   };

--- a/src/config/parser.ts
+++ b/src/config/parser.ts
@@ -29,25 +29,41 @@ export const parseKintoneMcpServerConfig = (): ParsedConfig => {
   );
 };
 
+const emptyToUndefined = (value: string | undefined): string | undefined => {
+  return value === "" ? undefined : value;
+};
+
 export const merge = (
   env: Record<string, string | undefined>,
   args: Record<string, string | undefined>,
 ): Partial<ProvidedConfig> => {
   return {
-    KINTONE_BASE_URL: args["base-url"] ?? env.KINTONE_BASE_URL,
-    KINTONE_USERNAME: args.username ?? env.KINTONE_USERNAME,
-    KINTONE_PASSWORD: args.password ?? env.KINTONE_PASSWORD,
-    KINTONE_API_TOKEN: args["api-token"] ?? env.KINTONE_API_TOKEN,
-    KINTONE_BASIC_AUTH_USERNAME:
+    KINTONE_BASE_URL: emptyToUndefined(
+      args["base-url"] ?? env.KINTONE_BASE_URL,
+    ),
+    KINTONE_USERNAME: emptyToUndefined(args.username ?? env.KINTONE_USERNAME),
+    KINTONE_PASSWORD: emptyToUndefined(args.password ?? env.KINTONE_PASSWORD),
+    KINTONE_API_TOKEN: emptyToUndefined(
+      args["api-token"] ?? env.KINTONE_API_TOKEN,
+    ),
+    KINTONE_BASIC_AUTH_USERNAME: emptyToUndefined(
       args["basic-auth-username"] ?? env.KINTONE_BASIC_AUTH_USERNAME,
-    KINTONE_BASIC_AUTH_PASSWORD:
+    ),
+    KINTONE_BASIC_AUTH_PASSWORD: emptyToUndefined(
       args["basic-auth-password"] ?? env.KINTONE_BASIC_AUTH_PASSWORD,
-    KINTONE_PFX_FILE_PATH: args["pfx-file-path"] ?? env.KINTONE_PFX_FILE_PATH,
-    KINTONE_PFX_FILE_PASSWORD:
+    ),
+    KINTONE_PFX_FILE_PATH: emptyToUndefined(
+      args["pfx-file-path"] ?? env.KINTONE_PFX_FILE_PATH,
+    ),
+    KINTONE_PFX_FILE_PASSWORD: emptyToUndefined(
       args["pfx-file-password"] ?? env.KINTONE_PFX_FILE_PASSWORD,
-    HTTPS_PROXY: args.proxy ?? env.HTTPS_PROXY ?? env.https_proxy,
-    KINTONE_ATTACHMENTS_DIR:
+    ),
+    HTTPS_PROXY: emptyToUndefined(
+      args.proxy ?? env.HTTPS_PROXY ?? env.https_proxy,
+    ),
+    KINTONE_ATTACHMENTS_DIR: emptyToUndefined(
       args["attachments-dir"] ?? env.KINTONE_ATTACHMENTS_DIR,
+    ),
   };
 };
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,8 +5,8 @@ export const PACKAGE_NAME = "@kintone/mcp-server";
 export const configSchema = z
   .object({
     KINTONE_BASE_URL: z
-      .string()
-      .url()
+      .string({ required_error: "Required (e.g., https://example.cybozu.com)" })
+      .url("Must be a valid URL (e.g., https://example.cybozu.com)")
       .describe(
         "The base URL of your kintone environment (e.g., https://example.cybozu.com)",
       ),
@@ -51,11 +51,9 @@ export const configSchema = z
     HTTPS_PROXY: z
       .string()
       .optional()
-      .refine(
-        (value) =>
-          !value || value === "" || z.string().url().safeParse(value).success,
-        { message: "Invalid proxy URL format" },
-      )
+      .refine((value) => !value || z.string().url().safeParse(value).success, {
+        message: "Must be a valid URL (e.g., http://proxy.example.com:8080)",
+      })
       .describe("HTTPS proxy URL (e.g., http://proxy.example.com:8080)"),
     KINTONE_PFX_FILE_PATH: z
       .string()

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,13 @@ import {
   getMcpServerConfig,
   getToolConditionConfig,
 } from "./config/index.js";
+import { PACKAGE_NAME } from "./config/schema.js";
+
+const log = (...args: unknown[]) => console.error(`[${PACKAGE_NAME}]`, ...args);
 
 const main = async () => {
   const transport = new StdioServerTransport();
-  console.error("Starting server...");
+  log("Starting server...");
 
   const mcpServerConfig = getMcpServerConfig();
   const clientConfig = getKintoneClientConfig();
@@ -31,4 +34,8 @@ const main = async () => {
   await server.connect(transport);
 };
 
-main().catch(console.error);
+main().catch((error) => {
+  log(error);
+  // eslint-disable-next-line n/no-process-exit
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

`src/config/index.ts` ran `parseKintoneMcpServerConfig()` at the top level (ESM module evaluation time), making config validation errors uncatchable by `main().catch(console.error)`. In Claude Desktop (mcpb), this caused silent crashes with only "Server transport closed unexpectedly" in the logs — no error details visible to users.

Additionally, mcpb sets `"default": ""` for optional `user_config` fields, causing empty strings to fail Zod `.min(1)` validation even when they should be treated as "not provided".

## What

- **Lazy singleton**: Convert top-level config parse to a lazy singleton (`getConfig()`) that defers parsing to first access within `main()` scope, making errors catchable
- **Empty string handling**: Add `emptyToUndefined()` in `merge()` to normalize `""` → `undefined` before schema validation
- **Error messages**: Add concrete URL examples to validation errors (e.g., `Required (e.g., https://example.cybozu.com)`)
- **Exit code**: Add `process.exit(1)` so the process signals failure properly
- **Log prefix**: Add `[@kintone/mcp-server]` prefix to stderr output for searchability in Claude Desktop's `main.log`

## How to test

```bash
# Config error is now caught and displayed with improved messages
KINTONE_BASE_URL=invalid npx @kintone/mcp-server
# → [@kintone/mcp-server] Error: Environment variables are missing or invalid:
#   KINTONE_BASE_URL: Must be a valid URL (e.g., https://example.cybozu.com)
#   Either KINTONE_USERNAME/KINTONE_PASSWORD or KINTONE_API_TOKEN must be provided

# Empty string username/password with valid API token succeeds
KINTONE_BASE_URL=https://example.cybozu.com KINTONE_USERNAME="" KINTONE_PASSWORD="" KINTONE_API_TOKEN=abc123 npx @kintone/mcp-server
# → [@kintone/mcp-server] Starting server...
```

## Checklist

- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.