### PR TITLE
refactor: remove module-level singleton cache from kintone client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ```typescript
 const config = parseKintoneClientConfig();
-const client = getKintoneClient(config);
+const client = createKintoneClient(config);
 ```
 
 ### テスト作成時の注意点

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -38,15 +38,15 @@ vi.mock("fs", () => ({
   readFileSync: mockReadFileSync,
 }));
 
-describe("getKintoneClient", () => {
-  let getKintoneClient: any;
+describe("createKintoneClient", () => {
+  let createKintoneClient: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
     // Import fresh module instance for each test
     const module = await import("../index.js");
-    getKintoneClient = module.getKintoneClient;
+    createKintoneClient = module.createKintoneClient;
   });
 
   describe("basic functionality", () => {
@@ -54,7 +54,7 @@ describe("getKintoneClient", () => {
       const mockClientInstance = { app: { getApp: vi.fn() } };
       mockKintoneClient.mockReturnValue(mockClientInstance);
 
-      const result = getKintoneClient(mockKintoneConfig);
+      const result = createKintoneClient(mockKintoneConfig);
 
       expect(mockKintoneClient).toHaveBeenCalledWith({
         baseUrl: mockKintoneConfig.KINTONE_BASE_URL,
@@ -68,15 +68,19 @@ describe("getKintoneClient", () => {
       expect(result).toBe(mockClientInstance);
     });
 
-    it("should return the same instance on subsequent calls (singleton)", () => {
-      const mockClientInstance = { app: { getApp: vi.fn() } };
-      mockKintoneClient.mockReturnValue(mockClientInstance);
+    it("should create a new instance on each call", () => {
+      const mockClientInstance1 = { app: { getApp: vi.fn() } };
+      const mockClientInstance2 = { app: { getApp: vi.fn() } };
+      mockKintoneClient
+        .mockReturnValueOnce(mockClientInstance1)
+        .mockReturnValueOnce(mockClientInstance2);
 
-      const client1 = getKintoneClient(mockKintoneConfig);
-      const client2 = getKintoneClient(mockKintoneConfig);
+      const client1 = createKintoneClient(mockKintoneConfig);
+      const client2 = createKintoneClient(mockKintoneConfig);
 
-      expect(client1).toBe(client2);
-      expect(mockKintoneClient).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(mockClientInstance1);
+      expect(client2).toBe(mockClientInstance2);
+      expect(mockKintoneClient).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -85,7 +89,7 @@ describe("getKintoneClient", () => {
       const mockClientInstance = { app: { getApp: vi.fn() } };
       mockKintoneClient.mockReturnValue(mockClientInstance);
 
-      getKintoneClient(mockKintoneConfig);
+      createKintoneClient(mockKintoneConfig);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -101,7 +105,7 @@ describe("getKintoneClient", () => {
       const mockClientInstance = { app: { getApp: vi.fn() } };
       mockKintoneClient.mockReturnValue(mockClientInstance);
 
-      getKintoneClient(mockKintoneConfigWithApiToken);
+      createKintoneClient(mockKintoneConfigWithApiToken);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -121,7 +125,7 @@ describe("getKintoneClient", () => {
         KINTONE_API_TOKEN: "some-token",
       };
 
-      getKintoneClient(config);
+      createKintoneClient(config);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -145,7 +149,7 @@ describe("getKintoneClient", () => {
         KINTONE_BASIC_AUTH_PASSWORD: "basicpass",
       };
 
-      getKintoneClient(config);
+      createKintoneClient(config);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -167,7 +171,7 @@ describe("getKintoneClient", () => {
         KINTONE_BASIC_AUTH_PASSWORD: undefined,
       };
 
-      getKintoneClient(config);
+      createKintoneClient(config);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.not.objectContaining({
@@ -190,7 +194,7 @@ describe("getKintoneClient", () => {
         HTTPS_PROXY: "http://proxy.example.com:8080",
       };
 
-      getKintoneClient(config);
+      createKintoneClient(config);
 
       expect(mockHttpsProxyAgent).toHaveBeenCalledWith(
         "http://proxy.example.com:8080",
@@ -207,7 +211,7 @@ describe("getKintoneClient", () => {
       const mockClientInstance = { app: { getApp: vi.fn() } };
       mockKintoneClient.mockReturnValue(mockClientInstance);
 
-      getKintoneClient(mockKintoneConfig);
+      createKintoneClient(mockKintoneConfig);
 
       expect(mockKintoneClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -228,7 +232,7 @@ describe("getKintoneClient", () => {
         KINTONE_PFX_FILE_PASSWORD: "pfx-password",
       };
 
-      getKintoneClient(config);
+      createKintoneClient(config);
 
       expect(mockReadFileSync).toHaveBeenCalledWith("/path/to/cert.pfx");
       expect(mockKintoneClient).toHaveBeenCalledWith(
@@ -249,7 +253,7 @@ describe("getKintoneClient", () => {
         KINTONE_PFX_FILE_PASSWORD: "pfx-password",
       };
 
-      expect(() => getKintoneClient(config)).toThrow(
+      expect(() => createKintoneClient(config)).toThrow(
         "Failed to read PFX file: /invalid/path.pfx. File not found",
       );
     });
@@ -266,7 +270,7 @@ describe("getKintoneClient", () => {
         HTTPS_PROXY: "invalid-url",
       };
 
-      expect(() => getKintoneClient(config)).toThrow(
+      expect(() => createKintoneClient(config)).toThrow(
         "Invalid HTTPS proxy URL: [invalid proxy URL]. Invalid URL",
       );
     });
@@ -281,7 +285,7 @@ describe("getKintoneClient", () => {
         HTTPS_PROXY: "http://user:pass@proxy.example.com:8080",
       };
 
-      expect(() => getKintoneClient(config)).toThrow(
+      expect(() => createKintoneClient(config)).toThrow(
         "Invalid HTTPS proxy URL: http://proxy.example.com:8080/. Connection refused",
       );
     });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,17 +4,11 @@ import { Agent, type AgentOptions } from "https";
 import { readFileSync } from "fs";
 import type { KintoneClientConfig } from "./types/client.js";
 
-let client: KintoneRestAPIClient | null = null;
-
 export type { KintoneClientConfig };
 
-export const getKintoneClient = (
+export const createKintoneClient = (
   config: KintoneClientConfig,
 ): KintoneRestAPIClient => {
-  if (client) {
-    return client;
-  }
-
   const {
     KINTONE_BASE_URL,
     KINTONE_USERNAME,
@@ -34,7 +28,7 @@ export const getKintoneClient = (
     apiToken: KINTONE_API_TOKEN,
   });
 
-  client = new KintoneRestAPIClient({
+  return new KintoneRestAPIClient({
     baseUrl: KINTONE_BASE_URL,
     ...authParams,
     ...buildBasicAuthParam({
@@ -48,8 +42,6 @@ export const getKintoneClient = (
       pfxPassword: KINTONE_PFX_FILE_PASSWORD,
     }),
   });
-
-  return client;
 };
 
 const buildAuthParams = (option: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldEnableTool } from "./tool-filters.js";
-import { getKintoneClient } from "../client/index.js";
+import { createKintoneClient } from "../client/index.js";
 import { createToolCallback, tools } from "../tools/index.js";
 import type { KintoneMcpServerOptions } from "./types/server.js";
 
@@ -11,7 +11,7 @@ export const createServer = (options: KintoneMcpServerOptions): McpServer => {
     version: options.version,
   });
 
-  const client = getKintoneClient(options.config.clientConfig);
+  const client = createKintoneClient(options.config.clientConfig);
   const toolCondition = options.config.toolConditionConfig;
   const attachmentsDir = options.config.fileConfig.attachmentsDir;
   tools


### PR DESCRIPTION
## Why

`getKintoneClient` caches a single `KintoneRestAPIClient` instance in a module-level variable and returns it on every subsequent call. This couples all callers to one shared instance and makes testing harder — each test must call `vi.resetModules()` to get a clean slate.

Removing the cache lets callers create isolated client instances with different configurations, which is a prerequisite for any future scenario where multiple configurations coexist (e.g. testing, or per-request clients).

## What

- Remove the `let client` module-level cache and the early-return guard in `src/client/index.ts`
- Rename `getKintoneClient` → `createKintoneClient` to reflect the new "always creates" semantics
- Update `src/server/index.ts` to use the renamed function
- Replace the singleton test with a test verifying that each call produces a new instance

For the current stdio transport, `createServer` is called once, so this change has no observable effect on runtime behavior.

## How to test

```bash
pnpm test
pnpm typecheck
```

All 674 existing tests pass without modification (other than the renamed import and the updated singleton test).

## Checklist

- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.