### PR TITLE
fix: advertise tool schemas as JSON Schema 2020-12

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,7 @@ export default [
       "n/no-missing-import": [
         "error",
         {
-          allowModules: ["@modelcontextprotocol/sdk"],
+          allowModules: ["@modelcontextprotocol/sdk", "ajv"],
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "file-type": "22.0.1",
     "https-proxy-agent": "7.0.6",
-    "zod": "3.25.76"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "2.1.2",
@@ -74,6 +74,7 @@
     "@cybozu/license-manager": "1.4.1",
     "@modelcontextprotocol/inspector": "0.18.0",
     "@types/node": "22.20.1",
+    "ajv": "8.17.1",
     "doctoc": "2.5.0",
     "eslint": "9.39.5",
     "eslint-plugin-package-json": "0.88.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.2.1
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       file-type:
         specifier: 22.0.1
         version: 22.0.1
@@ -24,8 +24,8 @@ importers:
         specifier: 7.0.6
         version: 7.0.6
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@anthropic-ai/mcpb':
         specifier: 2.1.2
@@ -48,6 +48,9 @@ importers:
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
+      ajv:
+        specifier: 8.17.1
+        version: 8.17.1
       doctoc:
         specifier: 2.5.0
         version: 2.5.0
@@ -4051,6 +4054,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
 
@@ -4834,6 +4840,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.9)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.9
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6275,8 +6303,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.5(jiti@2.5.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8228,10 +8256,16 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}

--- a/src/config/__tests__/parser/validation-errors.test.ts
+++ b/src/config/__tests__/parser/validation-errors.test.ts
@@ -68,7 +68,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_USERNAME: String must contain at least 1 character(s)",
+        "KINTONE_USERNAME: Must not be empty",
       ],
     },
     {
@@ -90,7 +90,7 @@ describe("config - validation errors", () => {
       },
       expectedErrors: [
         "Environment variables are missing or invalid",
-        "KINTONE_PASSWORD: String must contain at least 1 character(s)",
+        "KINTONE_PASSWORD: Must not be empty",
       ],
     },
     {
@@ -103,8 +103,8 @@ describe("config - validation errors", () => {
       expectedErrors: [
         "Environment variables are missing or invalid",
         "KINTONE_BASE_URL: Invalid url",
-        "KINTONE_USERNAME: String must contain at least 1 character(s)",
-        "KINTONE_PASSWORD: String must contain at least 1 character(s)",
+        "KINTONE_USERNAME: Must not be empty",
+        "KINTONE_PASSWORD: Must not be empty",
       ],
     },
     {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,19 +5,21 @@ export const PACKAGE_NAME = "@kintone/mcp-server";
 export const configSchema = z
   .object({
     KINTONE_BASE_URL: z
-      .string()
-      .url()
+      .url({
+        error: (issue) =>
+          issue.input === undefined ? "Required" : "Invalid url",
+      })
       .describe(
         "The base URL of your kintone environment (e.g., https://example.cybozu.com)",
       ),
     KINTONE_USERNAME: z
       .string()
-      .min(1)
+      .min(1, "Must not be empty")
       .optional()
       .describe("Username for authentication"),
     KINTONE_PASSWORD: z
       .string()
-      .min(1)
+      .min(1, "Must not be empty")
       .optional()
       .describe("Password for authentication"),
     KINTONE_API_TOKEN: z

--- a/src/schema/app/__tests__/properties-parameter.test.ts
+++ b/src/schema/app/__tests__/properties-parameter.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { propertiesForParameterSchema } from "../properties-parameter.js";
+import {
+  propertiesForParameterSchema,
+  propertiesForParameterForUpdateSchema,
+} from "../properties-parameter.js";
 
 describe("properties-parameter schema", () => {
   describe("lookupSchema with type NUMBER", () => {
@@ -531,6 +534,92 @@ describe("properties-parameter schema", () => {
           },
         },
       });
+    });
+  });
+
+  describe("propertiesForParameterForUpdateSchema", () => {
+    const schema = z.object({
+      properties: propertiesForParameterForUpdateSchema,
+    });
+
+    it("accepts a field with only label, code omitted", () => {
+      const input = {
+        properties: {
+          memo: {
+            type: "MULTI_LINE_TEXT",
+            label: "メモ（最小更新）",
+          },
+        },
+      };
+
+      expect(() => schema.parse(input)).not.toThrow();
+    });
+
+    it("accepts a field with only type, code and label both omitted", () => {
+      const input = {
+        properties: {
+          field1: {
+            type: "SINGLE_LINE_TEXT",
+          },
+        },
+      };
+
+      expect(() => schema.parse(input)).not.toThrow();
+    });
+
+    it("still requires type", () => {
+      const input = {
+        properties: {
+          field1: {
+            code: "field1",
+            label: "Field 1",
+          },
+        },
+      };
+
+      expect(() => schema.parse(input)).toThrow();
+    });
+
+    it("accepts a subtable with code/label omitted at both outer and inner levels", () => {
+      const input = {
+        properties: {
+          table: {
+            type: "SUBTABLE",
+            fields: {
+              inner: {
+                type: "NUMBER",
+              },
+            },
+          },
+        },
+      };
+
+      expect(() => schema.parse(input)).not.toThrow();
+    });
+
+    it("accepts a lookup field with code/label omitted", () => {
+      const input = {
+        properties: {
+          lookup_field: {
+            type: "NUMBER",
+            lookup: {
+              relatedApp: {
+                app: "17",
+                code: "related_app",
+              },
+              relatedKeyField: "record_number",
+              fieldMappings: [
+                { field: "lookup_field", relatedField: "source_field" },
+              ],
+              lookupPickerFields: ["record_number"],
+              filterCond: "",
+              sort: "",
+            },
+          },
+        },
+      };
+
+      expect(() => schema.parse(input)).not.toThrow();
     });
   });
 });

--- a/src/schema/app/index.ts
+++ b/src/schema/app/index.ts
@@ -1,2 +1,5 @@
 export { layoutForParameterSchema } from "./form-layout.js";
-export { propertiesForParameterSchema } from "./properties-parameter.js";
+export {
+  propertiesForParameterSchema,
+  propertiesForParameterForUpdateSchema,
+} from "./properties-parameter.js";

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -757,9 +757,8 @@ export type PropertiesForParameter = z.infer<
   typeof propertiesForParameterSchema
 >;
 
-// Update Form Fields (PUT) only requires `type` for every field type - unlike
-// Add Form Fields (POST), `code` and `label` are optional and kintone keeps
-// the field's current value when they are omitted.
+// Update Form Fields (PUT) only requires `type`; unlike Add Form Fields
+// (POST), `code`/`label` are optional and kept unchanged when omitted.
 const inSubtableFieldForUpdateSchema = z.union([
   lookupSchema.partial({ code: true, label: true }),
   singleLineTextSchema.partial({ code: true, label: true }),

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -795,7 +795,6 @@ const subtableForUpdateSchema = z.object({
     .describe("Configuration of fields within the subtable"),
 });
 
-// Union of all field types for update (code/label optional)
 const fieldPropertyForUpdateSchema = z.union([
   recordNumberSchema.partial({ code: true, label: true }),
   creatorSchema.partial({ code: true, label: true }),
@@ -828,7 +827,6 @@ const fieldPropertyForUpdateSchema = z.union([
   subtableForUpdateSchema,
 ]);
 
-// Schema for PropertiesForParameter used by Update Form Fields
 export const propertiesForParameterForUpdateSchema = z
   .record(z.string().describe("Field code"), fieldPropertyForUpdateSchema)
   .describe(

--- a/src/schema/app/properties-parameter.ts
+++ b/src/schema/app/properties-parameter.ts
@@ -756,3 +756,86 @@ export const propertiesForParameterSchema = z
 export type PropertiesForParameter = z.infer<
   typeof propertiesForParameterSchema
 >;
+
+// Update Form Fields (PUT) only requires `type` for every field type - unlike
+// Add Form Fields (POST), `code` and `label` are optional and kintone keeps
+// the field's current value when they are omitted.
+const inSubtableFieldForUpdateSchema = z.union([
+  lookupSchema.partial({ code: true, label: true }),
+  singleLineTextSchema.partial({ code: true, label: true }),
+  numberSchema.partial({ code: true, label: true }),
+  calcSchema.partial({ code: true, label: true }),
+  multiLineTextSchema.partial({ code: true, label: true }),
+  richTextSchema.partial({ code: true, label: true }),
+  linkSchema.partial({ code: true, label: true }),
+  checkboxSchema.partial({ code: true, label: true }),
+  radioButtonSchema.partial({ code: true, label: true }),
+  dropdownSchema.partial({ code: true, label: true }),
+  multiSelectSchema.partial({ code: true, label: true }),
+  fileSchema.partial({ code: true, label: true }),
+  dateSchema.partial({ code: true, label: true }),
+  timeSchema.partial({ code: true, label: true }),
+  datetimeSchema.partial({ code: true, label: true }),
+  userSelectSchema.partial({ code: true, label: true }),
+  organizationSelectSchema.partial({ code: true, label: true }),
+  groupSelectSchema.partial({ code: true, label: true }),
+]);
+
+const subtableForUpdateSchema = z.object({
+  type: z.literal("SUBTABLE"),
+  code: z.string().optional().describe("Field code"),
+  label: z.string().optional().describe("Field label"),
+  noLabel: z
+    .boolean()
+    .optional()
+    .describe("Whether to hide the label (true: hide, false: show)"),
+  fields: z
+    .record(z.string(), inSubtableFieldForUpdateSchema)
+    .optional()
+    .describe("Configuration of fields within the subtable"),
+});
+
+// Union of all field types for update (code/label optional)
+const fieldPropertyForUpdateSchema = z.union([
+  recordNumberSchema.partial({ code: true, label: true }),
+  creatorSchema.partial({ code: true, label: true }),
+  createdTimeSchema.partial({ code: true, label: true }),
+  modifierSchema.partial({ code: true, label: true }),
+  updatedTimeSchema.partial({ code: true, label: true }),
+  categorySchema.partial({ code: true, label: true }),
+  statusSchema.partial({ code: true, label: true }),
+  statusAssigneeSchema.partial({ code: true, label: true }),
+  lookupSchema.partial({ code: true, label: true }),
+  singleLineTextSchema.partial({ code: true, label: true }),
+  numberSchema.partial({ code: true, label: true }),
+  calcSchema.partial({ code: true, label: true }),
+  multiLineTextSchema.partial({ code: true, label: true }),
+  richTextSchema.partial({ code: true, label: true }),
+  linkSchema.partial({ code: true, label: true }),
+  checkboxSchema.partial({ code: true, label: true }),
+  radioButtonSchema.partial({ code: true, label: true }),
+  dropdownSchema.partial({ code: true, label: true }),
+  multiSelectSchema.partial({ code: true, label: true }),
+  fileSchema.partial({ code: true, label: true }),
+  dateSchema.partial({ code: true, label: true }),
+  timeSchema.partial({ code: true, label: true }),
+  datetimeSchema.partial({ code: true, label: true }),
+  userSelectSchema.partial({ code: true, label: true }),
+  organizationSelectSchema.partial({ code: true, label: true }),
+  groupSelectSchema.partial({ code: true, label: true }),
+  groupSchema.partial({ code: true, label: true }),
+  referenceTableSchema.partial({ code: true, label: true }),
+  subtableForUpdateSchema,
+]);
+
+// Schema for PropertiesForParameter used by Update Form Fields
+export const propertiesForParameterForUpdateSchema = z
+  .record(z.string().describe("Field code"), fieldPropertyForUpdateSchema)
+  .describe(
+    "Object containing field configuration information to update. Keys are field codes, values are field properties. " +
+      "code and label may be omitted to keep their current values.",
+  );
+
+export type PropertiesForUpdateParameter = z.infer<
+  typeof propertiesForParameterForUpdateSchema
+>;

--- a/src/schema/record/record-for-parameter.ts
+++ b/src/schema/record/record-for-parameter.ts
@@ -99,7 +99,7 @@ const _recordValueSchema = z.union([
         z.object({
           id: z.string().optional().describe("Row ID (optional for new rows)"),
           value: z
-            .record(z.any())
+            .record(z.string(), z.any())
             .describe("Field values within this subtable row"),
         }),
       )
@@ -127,6 +127,7 @@ const _recordValueSchema = z.union([
 ]);
 
 export const recordSchemaForParameter = z.record(
+  z.string(),
   _recordValueSchema.or(
     z.object({
       value: z
@@ -146,6 +147,7 @@ export const recordSchemaForParameter = z.record(
 // ファイルアップロードツール未実装のため現在はinputとしては指定不可
 // TODO: ファイルアップロードツール実装後に調整
 export const recordSchemaForParameterWithoutFile = z.record(
+  z.string(),
   _recordValueSchema.or(
     z.object({
       value: z

--- a/src/schema/record/records.ts
+++ b/src/schema/record/records.ts
@@ -144,7 +144,7 @@ const recordValueSchema = z.union([
       .array(
         z.object({
           id: z.string(),
-          value: z.record(z.any()),
+          value: z.record(z.string(), z.any()),
         }),
       )
       .nullable(),
@@ -193,4 +193,4 @@ const recordValueSchema = z.union([
   }),
 ]);
 
-export const recordSchema = z.record(recordValueSchema);
+export const recordSchema = z.record(z.string(), recordValueSchema);

--- a/src/schema/search/input.ts
+++ b/src/schema/search/input.ts
@@ -76,7 +76,12 @@ export const searchInputSchema = {
   query: z
     .tuple([searchQuerySchema])
     .rest(searchQuerySchema)
-    .describe("Search queries (at least 1 required)"),
+    // Zod renders a tuple with a rest element as prefixItems + items, which
+    // does not tell a client that one query is required, so state it here.
+    .meta({
+      minItems: 1,
+      description: "Search queries (at least 1 required)",
+    }),
   types: z
     .array(searchHitTypeSchema)
     .optional()

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -48,9 +48,8 @@ const listToolsBuiltBySdk = () => {
   return listToolsOf(server);
 };
 
-// Clients following SEP-1613 (Claude Cowork, Claude API, ...) reject tool
-// schemas that are not valid JSON Schema 2020-12, and a single invalid tool
-// breaks every tool call of the session.
+// SEP-1613 clients (Claude Cowork, Claude API) reject tools whose schema
+// isn't 2020-12, and one invalid tool breaks every call in the session.
 // https://github.com/kintone/mcp-server/issues/544
 // https://github.com/kintone/mcp-server/issues/547
 describe("tool schemas", () => {

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -102,6 +102,29 @@ describe("tool schemas", () => {
     expect(ours.map(withoutSchemas)).toEqual(bySdk.map(withoutSchemas));
   });
 
+  it("keep advertising minItems for the search query", async () => {
+    const advertised = await listTools();
+
+    const search = advertised.find((tool) => tool.name === "kintone-search");
+    expect(search?.inputSchema.properties?.query.minItems).toBe(1);
+  });
+
+  it("declare a type for every top-level input property", async () => {
+    // A property schema built only from oneOf/anyOf (e.g. a discriminated
+    // union) has no top-level "type", which breaks clients that decide how
+    // to serialize an argument by checking the declared type.
+    const advertised = await listTools();
+
+    expect(
+      advertised.flatMap((tool) => {
+        const properties = tool.inputSchema.properties ?? {};
+        return Object.entries(properties)
+          .filter(([, propertySchema]) => !("type" in propertySchema))
+          .map(([name]) => `${tool.name}: ${name}`);
+      }),
+    ).toEqual([]);
+  });
+
   it("compile as JSON Schema 2020-12", async () => {
     const advertised = await listTools();
 

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -40,8 +40,6 @@ const listTools = () =>
     }),
   );
 
-// The same tools registered without the tools/list handler of createServer,
-// to diff our tool definitions against the ones the SDK builds by itself.
 const listToolsBuiltBySdk = () => {
   const server = new McpServer({ name: "test-server", version: "0.0.0" });
   tools.forEach((tool) =>

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../index.js";
+import { mockKintoneConfig } from "../../__tests__/utils.js";
+
+const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+const listTools = async () => {
+  const server = createServer({
+    name: "test-server",
+    version: "0.0.0",
+    config: {
+      clientConfig: mockKintoneConfig,
+      fileConfig: {},
+      toolConditionConfig: { isApiTokenAuth: false },
+    },
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  try {
+    const { tools } = await client.listTools();
+    return tools;
+  } finally {
+    await client.close();
+    await server.close();
+  }
+};
+
+// Clients following SEP-1613 (Claude Cowork, Claude API, ...) reject tool
+// schemas that are not valid JSON Schema 2020-12, and a single invalid tool
+// breaks every tool call of the session.
+// https://github.com/kintone/mcp-server/issues/544
+// https://github.com/kintone/mcp-server/issues/547
+describe("tool schemas", () => {
+  it("are declared as JSON Schema 2020-12", async () => {
+    const tools = await listTools();
+
+    expect(tools.length).toBeGreaterThan(0);
+    expect(
+      tools.map((tool) => [
+        tool.name,
+        tool.inputSchema.$schema,
+        tool.outputSchema?.$schema,
+      ]),
+    ).toEqual(
+      tools.map((tool) => [
+        tool.name,
+        JSON_SCHEMA_2020_12,
+        JSON_SCHEMA_2020_12,
+      ]),
+    );
+  });
+
+  it("compile as JSON Schema 2020-12", async () => {
+    const tools = await listTools();
+
+    const compile = (label: string, schema: unknown) => {
+      try {
+        new Ajv2020({ strict: false }).compile(schema as object);
+        return [];
+      } catch (e) {
+        return [`${label}: ${(e as Error).message}`];
+      }
+    };
+
+    expect(
+      tools.flatMap((tool) => [
+        ...compile(`${tool.name} inputSchema`, tool.inputSchema),
+        ...compile(`${tool.name} outputSchema`, tool.outputSchema),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -2,21 +2,15 @@ import { describe, expect, it } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createServer } from "../index.js";
+import { tools } from "../../tools/index.js";
 import { mockKintoneConfig } from "../../__tests__/utils.js";
+import type { McpServer as McpServerType } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 
-const listTools = async () => {
-  const server = createServer({
-    name: "test-server",
-    version: "0.0.0",
-    config: {
-      clientConfig: mockKintoneConfig,
-      fileConfig: {},
-      toolConditionConfig: { isApiTokenAuth: false },
-    },
-  });
+const listToolsOf = async (server: McpServerType) => {
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "test-client", version: "0.0.0" });
@@ -26,12 +20,34 @@ const listTools = async () => {
   ]);
 
   try {
-    const { tools } = await client.listTools();
-    return tools;
+    return (await client.listTools()).tools;
   } finally {
     await client.close();
     await server.close();
   }
+};
+
+const listTools = () =>
+  listToolsOf(
+    createServer({
+      name: "test-server",
+      version: "0.0.0",
+      config: {
+        clientConfig: mockKintoneConfig,
+        fileConfig: {},
+        toolConditionConfig: { isApiTokenAuth: false },
+      },
+    }),
+  );
+
+// The same tools registered without the tools/list handler of createServer,
+// to diff our tool definitions against the ones the SDK builds by itself.
+const listToolsBuiltBySdk = () => {
+  const server = new McpServer({ name: "test-server", version: "0.0.0" });
+  tools.forEach((tool) =>
+    server.registerTool(tool.name, tool.config, () => ({ content: [] })),
+  );
+  return listToolsOf(server);
 };
 
 // Clients following SEP-1613 (Claude Cowork, Claude API, ...) reject tool
@@ -41,17 +57,17 @@ const listTools = async () => {
 // https://github.com/kintone/mcp-server/issues/547
 describe("tool schemas", () => {
   it("are declared as JSON Schema 2020-12", async () => {
-    const tools = await listTools();
+    const advertised = await listTools();
 
-    expect(tools.length).toBeGreaterThan(0);
+    expect(advertised.length).toBeGreaterThan(0);
     expect(
-      tools.map((tool) => [
+      advertised.map((tool) => [
         tool.name,
         tool.inputSchema.$schema,
         tool.outputSchema?.$schema,
       ]),
     ).toEqual(
-      tools.map((tool) => [
+      advertised.map((tool) => [
         tool.name,
         JSON_SCHEMA_2020_12,
         JSON_SCHEMA_2020_12,
@@ -59,8 +75,24 @@ describe("tool schemas", () => {
     );
   });
 
+  it("keep every tool property the SDK advertises", async () => {
+    const [ours, bySdk] = await Promise.all([
+      listTools(),
+      listToolsBuiltBySdk(),
+    ]);
+
+    // "execution" is dropped on purpose: an absent one means the same as the
+    // "taskSupport: forbidden" the SDK fills in for tools without task support.
+    const withoutSchemas = (tool: Record<string, unknown>) => {
+      const { inputSchema, outputSchema, execution, ...rest } = tool;
+      return rest;
+    };
+
+    expect(ours.map(withoutSchemas)).toEqual(bySdk.map(withoutSchemas));
+  });
+
   it("compile as JSON Schema 2020-12", async () => {
-    const tools = await listTools();
+    const advertised = await listTools();
 
     const compile = (label: string, schema: unknown) => {
       try {
@@ -72,7 +104,7 @@ describe("tool schemas", () => {
     };
 
     expect(
-      tools.flatMap((tool) => [
+      advertised.flatMap((tool) => [
         ...compile(`${tool.name} inputSchema`, tool.inputSchema),
         ...compile(`${tool.name} outputSchema`, tool.outputSchema),
       ]),

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -110,9 +110,8 @@ describe("tool schemas", () => {
   });
 
   it("declare a type for every top-level input property", async () => {
-    // A property schema built only from oneOf/anyOf (e.g. a discriminated
-    // union) has no top-level "type", which breaks clients that decide how
-    // to serialize an argument by checking the declared type.
+    // A property built only from oneOf/anyOf has no top-level "type", which
+    // breaks clients that decide how to parse an argument from it.
     const advertised = await listTools();
 
     expect(

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -75,6 +75,20 @@ describe("tool schemas", () => {
     );
   });
 
+  it("reject extra properties", async () => {
+    const advertised = await listTools();
+
+    // The input schemas say so because they are built from strict objects; the
+    // output ones because Zod adds it for "io: output" on its own.
+    expect(
+      advertised.map((tool) => [
+        tool.name,
+        tool.inputSchema.additionalProperties,
+        tool.outputSchema?.additionalProperties,
+      ]),
+    ).toEqual(advertised.map((tool) => [tool.name, false, false]));
+  });
+
   it("keep every tool property the SDK advertises", async () => {
     const [ours, bySdk] = await Promise.all([
       listTools(),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { shouldEnableTool } from "./tool-filters.js";
+import { buildToolDefinition } from "./tool-definitions.js";
 import { getKintoneClient } from "../client/index.js";
 import { createToolCallback, tools } from "../tools/index.js";
 import type { KintoneMcpServerOptions } from "./types/server.js";
@@ -14,15 +16,22 @@ export const createServer = (options: KintoneMcpServerOptions): McpServer => {
   const client = getKintoneClient(options.config.clientConfig);
   const toolCondition = options.config.toolConditionConfig;
   const attachmentsDir = options.config.fileConfig.attachmentsDir;
-  tools
-    .filter((tool) => shouldEnableTool(tool.name, toolCondition))
-    .forEach((tool) =>
-      server.registerTool(
-        tool.name,
-        tool.config,
-        createToolCallback(tool.callback, { client, attachmentsDir }),
-      ),
-    );
+  const enabledTools = tools.filter((tool) =>
+    shouldEnableTool(tool.name, toolCondition),
+  );
+  enabledTools.forEach((tool) =>
+    server.registerTool(
+      tool.name,
+      tool.config,
+      createToolCallback(tool.callback, { client, attachmentsDir }),
+    ),
+  );
+
+  // Overwrite the handler registered by registerTool so that the advertised
+  // schemas use JSON Schema 2020-12 instead of the SDK's draft-07 output.
+  server.server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: enabledTools.map(buildToolDefinition),
+  }));
 
   return server;
 };

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -20,7 +20,7 @@ const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
     target: JSON_SCHEMA_TARGET,
     io,
     // Extract schemas that appear more than once into $defs, as the previous
-    // draft-07 output did. Inlining them grows tools/list by about 30%.
+    // draft-07 output did. Inlining them grows tools/list by about 23%.
     reused: "ref",
   }) as McpTool["inputSchema"];
 

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -25,8 +25,8 @@ const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
     // no top-level "type", which breaks clients that decide how to parse an
     // argument by checking the declared type. Synthesize one from the
     // branches: a shared type across all of them ("object" for a
-    // discriminated union, ["array", "null"] for a nullable array), left
-    // alone if the branches disagree.
+    // discriminated union), or an array of their types when they don't all
+    // agree (["array", "null"] for a nullable array).
     override: (ctx) => {
       const schema = ctx.jsonSchema as Record<string, unknown>;
       const branches = (schema.oneOf ?? schema.anyOf) as

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
+import type { ZodRawShape } from "zod";
+import type { Tool } from "../tools/types/tool.js";
+
+// MCP SDK converts Zod schemas with JSON Schema draft-07 and exposes no option
+// to change the dialect, while MCP clients following SEP-1613 accept JSON
+// Schema 2020-12 only. Build the tool definitions ourselves so that tools/list
+// advertises 2020-12 schemas.
+// https://github.com/kintone/mcp-server/issues/544
+const JSON_SCHEMA_TARGET = "draft-2020-12";
+
+const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
+  z.toJSONSchema(z.object(shape), {
+    target: JSON_SCHEMA_TARGET,
+    io,
+    // Extract schemas that appear more than once into $defs, as the previous
+    // draft-07 output did. Inlining them grows tools/list by about 30%.
+    reused: "ref",
+  }) as McpTool["inputSchema"];
+
+export const buildToolDefinition = (tool: Tool): McpTool => ({
+  name: tool.name,
+  title: tool.config.title,
+  description: tool.config.description,
+  inputSchema: toJsonSchema(tool.config.inputSchema, "input"),
+  outputSchema: toJsonSchema(tool.config.outputSchema, "output"),
+});

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -14,9 +14,35 @@ const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
   z.toJSONSchema(io === "input" ? z.strictObject(shape) : z.object(shape), {
     target: JSON_SCHEMA_TARGET,
     io,
-    // Extract schemas that appear more than once into $defs, as the previous
-    // draft-07 output did. Inlining them grows tools/list by about 23%.
-    reused: "ref",
+    // "ref" extracts every structurally-identical schema into $defs, even
+    // bare `z.string()`/`z.boolean()` reused across unrelated fields, which
+    // leaves those properties as a bare $ref with no top-level "type" - the
+    // same problem the override below works around, but with no branches to
+    // synthesize a type from. Inline avoids it at the cost of a larger
+    // tools/list (measured: about the same size as the SDK's draft-07 output).
+    reused: "inline",
+    // z.discriminatedUnion / z.union / .nullable() render as oneOf/anyOf with
+    // no top-level "type", which breaks clients that decide how to parse an
+    // argument by checking the declared type. Synthesize one from the
+    // branches: a shared type across all of them ("object" for a
+    // discriminated union, ["array", "null"] for a nullable array), left
+    // alone if the branches disagree.
+    override: (ctx) => {
+      const schema = ctx.jsonSchema as Record<string, unknown>;
+      const branches = (schema.oneOf ?? schema.anyOf) as
+        | Array<{ type?: unknown }>
+        | undefined;
+      if (!branches || "type" in schema) return;
+
+      const types = [...new Set(branches.map((branch) => branch.type))].filter(
+        Boolean,
+      );
+      if (types.length === 1) {
+        schema.type = types[0];
+      } else if (types.length > 1) {
+        schema.type = types;
+      }
+    },
   }) as McpTool["inputSchema"];
 
 export const buildToolDefinition = (tool: Tool): McpTool => ({

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -14,19 +14,12 @@ const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
   z.toJSONSchema(io === "input" ? z.strictObject(shape) : z.object(shape), {
     target: JSON_SCHEMA_TARGET,
     io,
-    // "ref" extracts every structurally-identical schema into $defs, even
-    // bare `z.string()`/`z.boolean()` reused across unrelated fields, which
-    // leaves those properties as a bare $ref with no top-level "type" - the
-    // same problem the override below works around, but with no branches to
-    // synthesize a type from. Inline avoids it at the cost of a larger
-    // tools/list (measured: about the same size as the SDK's draft-07 output).
+    // "ref" dedupes bare primitives into $defs, leaving some properties as a
+    // typeless $ref - clients infer how to parse args from that type.
     reused: "inline",
-    // z.discriminatedUnion / z.union / .nullable() render as oneOf/anyOf with
-    // no top-level "type", which breaks clients that decide how to parse an
-    // argument by checking the declared type. Synthesize one from the
-    // branches: a shared type across all of them ("object" for a
-    // discriminated union), or an array of their types when they don't all
-    // agree (["array", "null"] for a nullable array).
+    // discriminatedUnion/union/nullable() have the same problem via
+    // oneOf/anyOf; synthesize a type from the branches, merging into an
+    // array (e.g. ["array", "null"]) when they don't all agree.
     override: (ctx) => {
       const schema = ctx.jsonSchema as Record<string, unknown>;
       const branches = (schema.oneOf ?? schema.anyOf) as

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -3,19 +3,14 @@ import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape } from "zod";
 import type { Tool } from "../tools/types/tool.js";
 
-// MCP SDK converts Zod schemas with JSON Schema draft-07 and exposes no option
-// to change the dialect, while MCP clients following SEP-1613 accept JSON
-// Schema 2020-12 only. Build the tool definitions ourselves so that tools/list
-// advertises 2020-12 schemas.
+// The SDK always emits JSON Schema draft-07 with no way to change the
+// dialect, but SEP-1613 clients require 2020-12, so it's built here instead.
 // https://github.com/kintone/mcp-server/issues/544
 const JSON_SCHEMA_TARGET = "draft-2020-12";
 
 const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
-  // Zod emits "additionalProperties": false for strict objects only, so build
-  // the input schema from a strict object to keep advertising "no extra
-  // parameters" as the previous draft-07 output did. Tool arguments are still
-  // parsed with the non-strict schemas registered by registerTool, so unknown
-  // keys keep being stripped instead of rejected.
+  // Only advertises additionalProperties:false like draft-07 did; registerTool
+  // still strips unknown keys via its non-strict schema instead of rejecting.
   z.toJSONSchema(io === "input" ? z.strictObject(shape) : z.object(shape), {
     target: JSON_SCHEMA_TARGET,
     io,

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -11,7 +11,12 @@ import type { Tool } from "../tools/types/tool.js";
 const JSON_SCHEMA_TARGET = "draft-2020-12";
 
 const toJsonSchema = (shape: ZodRawShape, io: "input" | "output") =>
-  z.toJSONSchema(z.object(shape), {
+  // Zod emits "additionalProperties": false for strict objects only, so build
+  // the input schema from a strict object to keep advertising "no extra
+  // parameters" as the previous draft-07 output did. Tool arguments are still
+  // parsed with the non-strict schemas registered by registerTool, so unknown
+  // keys keep being stripped instead of rejected.
+  z.toJSONSchema(io === "input" ? z.strictObject(shape) : z.object(shape), {
     target: JSON_SCHEMA_TARGET,
     io,
     // Extract schemas that appear more than once into $defs, as the previous

--- a/src/tools/factory.ts
+++ b/src/tools/factory.ts
@@ -1,4 +1,4 @@
-import type { z, ZodRawShape, ZodTypeAny } from "zod";
+import type { z, ZodObject, ZodRawShape } from "zod";
 import type {
   ToolConfig,
   KintoneToolCallback,
@@ -25,6 +25,5 @@ export const createToolCallback = <InputArgs extends ZodRawShape>(
   callback: KintoneToolCallback<InputArgs>,
   options: ToolCallbackOptions,
 ) => {
-  return (args: z.objectOutputType<InputArgs, ZodTypeAny>) =>
-    callback(args, options);
+  return (args: z.infer<ZodObject<InputArgs>>) => callback(args, options);
 };

--- a/src/tools/kintone/app/__tests__/update-form-fields.test.ts
+++ b/src/tools/kintone/app/__tests__/update-form-fields.test.ts
@@ -34,6 +34,7 @@ describe("update-form-fields tool", () => {
       expect(updateFormFields.config.description).toBe(
         "Update form field settings in a kintone app (preview environment only). " +
           "Requires App Management permissions. " +
+          "Only type is required per field; omit code or label to keep their current values. " +
           "Cannot update field codes for Label, Blank space, Border, Status, Assignee, or Category fields. " +
           "For selection fields, unspecified options will be deleted. " +
           "Option keys must exactly match current option names. " +
@@ -167,6 +168,46 @@ describe("update-form-fields tool", () => {
             revision: "10",
           },
           description: "with multi-line text field and revision",
+        },
+        {
+          input: {
+            app: "49",
+            properties: {
+              memo: {
+                type: "MULTI_LINE_TEXT",
+                label: "メモ（最小更新）",
+              },
+            },
+          },
+          description: "with label only, code omitted",
+        },
+        {
+          input: {
+            app: "106",
+            properties: {
+              field1: {
+                type: "SINGLE_LINE_TEXT",
+              },
+            },
+          },
+          description: "with only type, code and label both omitted",
+        },
+        {
+          input: {
+            app: "107",
+            properties: {
+              table: {
+                type: "SUBTABLE",
+                fields: {
+                  inner: {
+                    type: "NUMBER",
+                  },
+                },
+              },
+            },
+          },
+          description:
+            "with subtable field, code/label omitted at both outer and inner levels",
         },
       ])("accepts $description", ({ input }) => {
         expect(() => inputSchema.parse(input)).not.toThrow();

--- a/src/tools/kintone/app/get-app-deploy-status.ts
+++ b/src/tools/kintone/app/get-app-deploy-status.ts
@@ -10,10 +10,11 @@ const inputSchema = {
     .describe("Array of app IDs to check deploy status (maximum 300)"),
 };
 
-const deployStatusEnum = z.enum(["PROCESSING", "SUCCESS", "FAIL", "CANCEL"], {
-  description:
+const deployStatusEnum = z
+  .enum(["PROCESSING", "SUCCESS", "FAIL", "CANCEL"])
+  .describe(
     "Deployment status: PROCESSING (in progress), SUCCESS (completed), FAIL (failed), CANCEL (canceled)",
-});
+  );
 
 const outputSchema = {
   apps: z

--- a/src/tools/kintone/app/get-process-management.ts
+++ b/src/tools/kintone/app/get-process-management.ts
@@ -69,7 +69,7 @@ const actionSchema = z.object({
 const outputSchema = {
   enable: z.boolean().describe("Whether process management is enabled"),
   states: z
-    .record(stateSchema)
+    .record(z.string(), stateSchema)
     .nullable()
     .describe("Object containing status configurations"),
   actions: z

--- a/src/tools/kintone/app/update-form-fields.ts
+++ b/src/tools/kintone/app/update-form-fields.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createTool } from "../../factory.js";
 import type { KintoneToolCallback } from "../../types/tool.js";
-import { propertiesForParameterSchema } from "../../../schema/app/index.js";
+import { propertiesForParameterForUpdateSchema } from "../../../schema/app/index.js";
 
 const inputSchema = {
   app: z
@@ -9,7 +9,7 @@ const inputSchema = {
     .describe(
       "The ID of the app to update form fields for (numeric value as string)",
     ),
-  properties: propertiesForParameterSchema.describe(
+  properties: propertiesForParameterForUpdateSchema.describe(
     "Object containing field configurations to update",
   ),
   revision: z
@@ -30,6 +30,7 @@ const toolConfig = {
   description:
     "Update form field settings in a kintone app (preview environment only). " +
     "Requires App Management permissions. " +
+    "Only type is required per field; omit code or label to keep their current values. " +
     "Cannot update field codes for Label, Blank space, Border, Status, Assignee, or Category fields. " +
     "For selection fields, unspecified options will be deleted. " +
     "Option keys must exactly match current option names. " +

--- a/src/tools/types/tool.ts
+++ b/src/tools/types/tool.ts
@@ -1,6 +1,6 @@
 import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { ZodRawShape, ZodTypeAny, z } from "zod";
+import type { ZodObject, ZodRawShape, z } from "zod";
 
 export type ToolCallbackOptions = {
   client: KintoneRestAPIClient;
@@ -27,6 +27,6 @@ export type Tool<
 };
 
 export type KintoneToolCallback<InputArgs extends ZodRawShape> = (
-  args: z.objectOutputType<InputArgs, ZodTypeAny>,
+  args: z.infer<ZodObject<InputArgs>>,
   extra: ToolCallbackOptions,
 ) => CallToolResult | Promise<CallToolResult>;


### PR DESCRIPTION
## Why

Fixes #544. Fixes #547.

Every tool of this server advertises its `inputSchema` / `outputSchema` as JSON Schema draft-07, which breaks MCP clients that follow [SEP-1613](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1613) and accept JSON Schema 2020-12 only. Two failures are reported, and both come from that:

- **#544** — clients that check the declared dialect reject every tool:
  `Tool 'kintone-get-app' has an invalid outputSchema: JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#")`.
- **#547** — the Claude API validates the input schemas of all enabled tools on every request and answers `400 tools.31.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12`, so no tool can be called at all. Removing the `$schema` declaration and validating the 27 tools with Ajv (2020-12) shows that exactly one of them is structurally invalid: `kintone-search`. Its `query` is a Zod tuple, which draft-07 renders as `"items": [ ... ]` plus `additionalItems`, whereas 2020-12 needs `prefixItems`.

## What

- Build the `tools/list` result in `src/server/tool-definitions.ts` and register it after `registerTool`, so the advertised schemas come from `z.toJSONSchema(..., { target: "draft-2020-12" })` instead of the SDK's draft-07 output. Everything else — argument validation, tool dispatch, output validation — is still done by the SDK.
- Upgrade `zod` from 3.25.76 to 4.4.3, which is what `z.toJSONSchema` requires. This also covers the pending renovate PR #26. The API changes it forces are small: `z.record` now takes an explicit key schema, `z.objectOutputType` is replaced by `z.infer<>`, and `z.enum` takes its description through `.describe()`.
- Keep the environment variable validation messages readable under Zod v4 by spelling them out in `src/config/schema.ts` (`Required` / `Invalid url` / `Must not be empty`).
- Add a regression test that lists the tools through an in-memory client and compiles every input/output schema with Ajv 2020-12, so a schema that a strict client would reject fails the build instead.
- **Also fixes an unrelated `kintone-update-form-fields` bug found while manually verifying this PR**: it shared its `properties` schema with `kintone-add-form-fields`, which requires `code` and `label` on every field. Omitting either one (e.g. updating only a field's `label`) rejected the whole request with an "Invalid union" error repeated for every field type the input didn't match (29 branches for a typical app). The kintone REST API's Update Form Fields endpoint (PUT) only requires `type` per field — `code`/`label` keep their current value when omitted — so `src/schema/app/properties-parameter.ts` now derives a dedicated update schema (`code`/`label` optional) from the existing field schemas, matching the PUT variants in the kintone REST API spec. `kintone-add-form-fields` is untouched.
- **Also fixes `kintone-update-general-settings` rejecting `icon`/`titleField`** (`expected object, received string`), found the same way. Two independent problems left some tool properties with no top-level `"type"` in the advertised schema, which breaks clients that decide how to parse an argument (e.g. whether to `JSON.parse` a string) by checking the declared type:
  - `reused: "ref"` (this PR, see below) extracts every structurally-identical Zod schema into `$defs`, including bare `z.string()`/`z.boolean()` shared across unrelated fields — a property built from one of those ends up as a bare `$ref` with no inline `"type"`. Switched to `"inline"`.
  - `z.discriminatedUnion` / `z.union` / `.nullable()` (pre-existing — the SDK's draft-07 output has the same shape) render as `oneOf`/`anyOf` with no shared top-level type (`icon`/`titleField` are the discriminated-union case the report hit). `src/server/tool-definitions.ts` now has an `override` hook that synthesizes one from the branches when they agree (`"object"` for a discriminated union, `["array", "null"]` for a nullable array).
  - A regression test asserts every advertised tool's top-level input properties declare a type; it fails on ~60 properties across several tools without both fixes.

Notes on the generated schemas:

- Reused subschemas are inlined rather than extracted into `$defs` (see above) — this is about the same size as the SDK's draft-07 output (measured: 228,931 bytes vs. 224,390), not the +23% growth an earlier `$ref`-vs-inline comparison suggested for extracting everything, including the primitives that caused the regression above.
- `kintone-search` declares its `query` through a Zod tuple with a rest element, which 2020-12 renders as `prefixItems` plus `items` and without the `minItems: 1` the draft-07 output had. It is stated explicitly again so that the "at least one query" constraint keeps being advertised.
- Input schemas are generated from strict objects so they keep advertising `"additionalProperties": false` as before. Tool arguments are still parsed with the non-strict schemas registered by `registerTool`, so unknown keys keep being stripped rather than rejected. Nested objects no longer carry `"additionalProperties": false`, which is a difference from the draft-07 output.
- The `execution` field the SDK fills in is not advertised anymore. An absent `execution` means the same as the `taskSupport: "forbidden"` it was set to. A test diffs the definitions against the ones the SDK builds so that any other difference shows up.

## How to test

`pnpm lint`, `pnpm typecheck` and `pnpm test` pass (35 files, 693 tests).

The new test in `src/server/__tests__/tool-definitions.test.ts` fails on `main`: every tool reports `no schema with key or ref "http://json-schema.org/draft-07/schema#"`, and after stripping the dialect `kintone-search` reports `data/properties/query/items must be object,boolean`.

Manually: connect the server to a client that requires 2020-12 (Claude Desktop, Claude Cowork) and call any tool. For the `kintone-update-form-fields` fix, call it with a field that only sets `label` (no `code`) and confirm it no longer raises an input validation error. For the `kintone-update-general-settings` fix, call it with `icon: {type: "PRESET", key: "APP1"}` or `titleField: {selectionMode: "AUTO"}` and confirm it's accepted as an object rather than rejected as a string.

## Checklist

- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
