### PR TITLE
feat: add kintone-upload-file tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 | `kintone-deploy-app`              | アプリ設定を運用環境へ反映             |
 | `kintone-update-general-settings` | アプリの一般設定を変更                 |
 | `kintone-download-file`           | 添付ファイルフィールドのファイルを保存 |
+| `kintone-upload-file`             | ファイルをアップロードしfileKeyを取得  |
 | `kintone-add-space-from-template` | テンプレートからスペースを作成         |
 | `kintone-update-space`            | スペースの設定を更新                   |
 | `kintone-get-space`               | スペースの情報を取得                   |

--- a/README_en.md
+++ b/README_en.md
@@ -200,34 +200,35 @@ export HTTPS_PROXY="http://username:password@proxy.example.com:8080"
 
 ## Tools
 
-| Tool Name                         | Description                                        |
-| --------------------------------- | -------------------------------------------------- |
-| `kintone-get-apps`                | Get information of multiple apps                   |
-| `kintone-get-app`                 | Get details of a single app                        |
-| `kintone-get-form-fields`         | Get app field settings                             |
-| `kintone-get-form-layout`         | Get app form layout                                |
-| `kintone-update-form-fields`      | Update app field settings                          |
-| `kintone-update-form-layout`      | Update app form layout                             |
-| `kintone-delete-form-fields`      | Delete app fields                                  |
-| `kintone-get-process-management`  | Get process management settings                    |
-| `kintone-get-app-deploy-status`   | Check app settings deployment status to production |
-| `kintone-get-general-settings`    | Get general settings of an app                     |
-| `kintone-add-form-fields`         | Add fields to an app                               |
-| `kintone-get-records`             | Get multiple records                               |
-| `kintone-add-records`             | Add multiple records                               |
-| `kintone-update-records`          | Update multiple records                            |
-| `kintone-delete-records`          | Delete multiple records                            |
-| `kintone-update-statuses`         | Update status of multiple records                  |
-| `kintone-get-record-comments`     | Get comments on a record                           |
-| `kintone-add-record-comment`      | Add a comment to a record                          |
-| `kintone-add-app`                 | Create app in pre-live environment                 |
-| `kintone-deploy-app`              | Deploy app settings to production                  |
-| `kintone-update-general-settings` | Update app general settings                        |
-| `kintone-download-file`           | Download and save a file from an attachment field  |
-| `kintone-add-space-from-template` | Create a new kintone space from a space template   |
-| `kintone-update-space`            | Update space settings                              |
-| `kintone-get-space`               | Get space information and portal settings          |
-| `kintone-delete-space`            | Delete a space                                     |
+| Tool Name                         | Description                                                  |
+| --------------------------------- | ------------------------------------------------------------ |
+| `kintone-get-apps`                | Get information of multiple apps                             |
+| `kintone-get-app`                 | Get details of a single app                                  |
+| `kintone-get-form-fields`         | Get app field settings                                       |
+| `kintone-get-form-layout`         | Get app form layout                                          |
+| `kintone-update-form-fields`      | Update app field settings                                    |
+| `kintone-update-form-layout`      | Update app form layout                                       |
+| `kintone-delete-form-fields`      | Delete app fields                                            |
+| `kintone-get-process-management`  | Get process management settings                              |
+| `kintone-get-app-deploy-status`   | Check app settings deployment status to production           |
+| `kintone-get-general-settings`    | Get general settings of an app                               |
+| `kintone-add-form-fields`         | Add fields to an app                                         |
+| `kintone-get-records`             | Get multiple records                                         |
+| `kintone-add-records`             | Add multiple records                                         |
+| `kintone-update-records`          | Update multiple records                                      |
+| `kintone-delete-records`          | Delete multiple records                                      |
+| `kintone-update-statuses`         | Update status of multiple records                            |
+| `kintone-get-record-comments`     | Get comments on a record                                     |
+| `kintone-add-record-comment`      | Add a comment to a record                                    |
+| `kintone-add-app`                 | Create app in pre-live environment                           |
+| `kintone-deploy-app`              | Deploy app settings to production                            |
+| `kintone-update-general-settings` | Update app general settings                                  |
+| `kintone-download-file`           | Download and save a file from an attachment field            |
+| `kintone-upload-file`             | Upload a local file to temporary storage and get its fileKey |
+| `kintone-add-space-from-template` | Create a new kintone space from a space template             |
+| `kintone-update-space`            | Update space settings                                        |
+| `kintone-get-space`               | Get space information and portal settings                    |
+| `kintone-delete-space`            | Delete a space                                               |
 
 ## Documentation
 

--- a/manifest.json
+++ b/manifest.json
@@ -133,6 +133,10 @@
       "description": "Download and save a file from a Kintone"
     },
     {
+      "name": "kintone-upload-file",
+      "description": "Upload one local file to the temporary storage of kintone via the File REST API (POST /k/v1/file.json) and return its fileKey. Only a single file can be uploaded per call. filePath must be an absolute path, or a file name resolved against KINTONE_ATTACHMENTS_DIR. The returned fileKey identifies the file in temporary storage and is what an attachment field expects when the file is attached to a record, a space, or an app setting; it is a different kind of key from the attachment fileKey returned by record retrieval. Uploading itself needs no specific permission. A file left in temporary storage without being attached is deleted after 3 days."
+    },
+    {
       "name": "kintone-add-space-from-template",
       "description": "Create a new kintone space from an existing space template via POST /k/v1/template/space.json. Requires permission to create spaces from templates (typically a kintone System Administrator, or a user explicitly granted space-creation rights). The members array must contain at least one entry with isAdmin: true; otherwise the API rejects the request. To create a guest space, the supplied template id must be a guest space template and isGuest must be true. The space is created immediately on the production environment (no deploy step); this operation is not reversible from this tool. Returns the id of the newly created space."
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cybozu/license-manager": "1.4.1",
     "@modelcontextprotocol/inspector": "0.18.0",
     "@types/node": "22.20.1",
-    "ajv": "8.18.0",
+    "ajv": "8.20.0",
     "doctoc": "2.5.0",
     "eslint": "9.39.5",
     "eslint-plugin-package-json": "0.88.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       ajv:
-        specifier: 8.18.0
-        version: 8.18.0
+        specifier: 8.20.0
+        version: 8.20.0
       doctoc:
         specifier: 2.5.0
         version: 2.5.0
@@ -1618,8 +1618,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anchor-markdown-header@0.8.4:
     resolution: {integrity: sha512-20eMBMpts7k5rXAAj67geSqc/tsexHZOZJDWQD214YcDuNtyizDa7Q77sYa5rkao2FwsQP1WKRt2X6mphwmhbg==}
@@ -4203,7 +4203,7 @@ snapshots:
   '@commitlint/config-validator@20.5.0':
     dependencies:
       '@commitlint/types': 20.5.0
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   '@commitlint/ensure@20.5.3':
     dependencies:
@@ -4824,8 +4824,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -4846,8 +4846,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -5553,9 +5553,9 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv@6.14.0:
     dependencies:
@@ -5564,7 +5564,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 4.1.1

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -35,6 +35,7 @@ export const createMockClient = (): KintoneRestAPIClient =>
     },
     file: {
       downloadFile: vi.fn(),
+      uploadFile: vi.fn(),
     },
     space: {
       addSpaceFromTemplate: vi.fn(),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,7 @@ import { addApp } from "./kintone/app/add-app.js";
 import { deployApp } from "./kintone/app/deploy-app.js";
 import { updateGeneralSettings } from "./kintone/app/update-general-settings.js";
 import { downloadFile } from "./kintone/file/download-file.js";
+import { uploadFile } from "./kintone/file/upload-file.js";
 import { addSpaceFromTemplate } from "./kintone/space/add-space-from-template.js";
 import { getSpace } from "./kintone/space/get-space.js";
 import { search } from "./kintone/search/search.js";
@@ -51,6 +52,7 @@ export const tools: Array<Tool<any, any>> = [
   deployApp,
   updateGeneralSettings,
   downloadFile,
+  uploadFile,
   addSpaceFromTemplate,
   getSpace,
   search,

--- a/src/tools/kintone/file/__tests__/upload-file.test.ts
+++ b/src/tools/kintone/file/__tests__/upload-file.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+import type * as NodeFs from "node:fs";
+import { createMockClient } from "../../../../__tests__/utils.js";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof NodeFs>("node:fs");
+  const mocked = {
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+  };
+  return {
+    ...actual,
+    ...mocked,
+    default: {
+      ...actual,
+      ...mocked,
+    },
+  };
+});
+
+import fs from "node:fs";
+import { uploadFile } from "../upload-file.js";
+
+const mockUploadFile = vi.fn();
+
+const expectedDescription =
+  "Upload one local file to the temporary storage of kintone via the File REST API (POST /k/v1/file.json) and return its fileKey. " +
+  "Only a single file can be uploaded per call, so repeat the call for each file. " +
+  "filePath must be an absolute path, or a file name resolved against KINTONE_ATTACHMENTS_DIR. " +
+  "The returned fileKey identifies the file in temporary storage and is what an attachment field expects when the file is attached to a record, a space, or an app setting. " +
+  "It is a different kind of key from the attachment fileKey returned by record retrieval, and such a retrieval fileKey cannot be re-uploaded or reused here. " +
+  "Uploading itself needs no specific permission; the permissions that matter are those of the operation that later attaches the file. " +
+  "A file left in temporary storage without being attached is deleted after 3 days, and files in temporary storage also count toward the disk usage of the domain.";
+
+const parseInput = (input: unknown) =>
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  z.object(uploadFile.config.inputSchema!).parse(input);
+
+const createClientWithUpload = () => {
+  const mockClient = createMockClient();
+  mockClient.file.uploadFile = mockUploadFile;
+  return mockClient;
+};
+
+describe("upload-file tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({
+      isFile: () => true,
+    } as NodeFs.Stats);
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      Buffer.from("file content"),
+    );
+    mockUploadFile.mockResolvedValue({ fileKey: "test-file-key" });
+  });
+
+  describe("tool configuration", () => {
+    it("should have correct name", () => {
+      expect(uploadFile.name).toBe("kintone-upload-file");
+    });
+
+    it("should have correct title and description", () => {
+      expect(uploadFile.config.title).toBe("Upload File to Kintone");
+      expect(uploadFile.config.description).toBe(expectedDescription);
+    });
+
+    it("should have valid input schema", () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const schema = z.object(uploadFile.config.inputSchema!);
+
+      expect(() =>
+        schema.parse({ filePath: "/tmp/uploads/report.pdf" }),
+      ).not.toThrow();
+      expect(() =>
+        schema.parse({
+          filePath: "/tmp/uploads/report.pdf",
+          fileName: "renamed.pdf",
+        }),
+      ).not.toThrow();
+
+      // Invalid input - missing or empty filePath
+      expect(() => schema.parse({})).toThrow();
+      expect(() => schema.parse({ filePath: "" })).toThrow();
+
+      // Invalid input - wrong types and empty fileName
+      expect(() => schema.parse({ filePath: 123 })).toThrow();
+      expect(() =>
+        schema.parse({ filePath: "/tmp/report.pdf", fileName: "" }),
+      ).toThrow();
+    });
+
+    it("should have valid output schema", () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const schema = z.object(uploadFile.config.outputSchema!);
+
+      const validOutput = {
+        fileKey: "c15b3870-7505-4ab6-9d8d-b9bdbc74f5d6",
+        fileName: "report.pdf",
+        fileSize: 1024,
+      };
+      expect(() => schema.parse(validOutput)).not.toThrow();
+
+      // Invalid output - missing required fields
+      expect(() => schema.parse({ fileKey: "key" })).toThrow();
+      // Invalid output - wrong type for fileSize
+      expect(() =>
+        schema.parse({ ...validOutput, fileSize: "1024" }),
+      ).toThrow();
+    });
+  });
+
+  describe("callback function", () => {
+    it("should upload a file specified by absolute path", async () => {
+      const params = parseInput({ filePath: "/tmp/uploads/report.pdf" });
+      const mockClient = createClientWithUpload();
+
+      const result = await uploadFile.callback(params, {
+        client: mockClient,
+        attachmentsDir: undefined,
+      });
+
+      expect(fs.promises.readFile).toHaveBeenCalledWith(
+        "/tmp/uploads/report.pdf",
+      );
+      expect(mockUploadFile).toHaveBeenCalledWith({
+        file: { name: "report.pdf", data: Buffer.from("file content") },
+      });
+      expect(result.structuredContent).toEqual({
+        fileKey: "test-file-key",
+        fileName: "report.pdf",
+        fileSize: Buffer.byteLength("file content"),
+      });
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: "text",
+        text: JSON.stringify(result.structuredContent, null, 2),
+      });
+    });
+
+    it("should resolve a relative path against attachmentsDir", async () => {
+      const params = parseInput({ filePath: "report.pdf" });
+      const mockClient = createClientWithUpload();
+
+      await uploadFile.callback(params, {
+        client: mockClient,
+        attachmentsDir: "/tmp/uploads",
+      });
+
+      expect(fs.existsSync).toHaveBeenCalledWith("/tmp/uploads/report.pdf");
+      expect(fs.promises.readFile).toHaveBeenCalledWith(
+        "/tmp/uploads/report.pdf",
+      );
+    });
+
+    it("should throw error when a relative path is given without attachmentsDir", async () => {
+      const params = parseInput({ filePath: "report.pdf" });
+      const mockClient = createClientWithUpload();
+
+      await expect(
+        uploadFile.callback(params, {
+          client: mockClient,
+          attachmentsDir: undefined,
+        }),
+      ).rejects.toThrow(
+        "filePath must be an absolute path unless KINTONE_ATTACHMENTS_DIR is set: report.pdf",
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+
+    it("should use fileName instead of the base name of filePath", async () => {
+      const params = parseInput({
+        filePath: "/tmp/uploads/report.pdf",
+        fileName: "見積書.pdf",
+      });
+      const mockClient = createClientWithUpload();
+
+      const result = await uploadFile.callback(params, {
+        client: mockClient,
+        attachmentsDir: undefined,
+      });
+
+      expect(mockUploadFile).toHaveBeenCalledWith({
+        file: { name: "見積書.pdf", data: Buffer.from("file content") },
+      });
+      expect(result.structuredContent).toMatchObject({
+        fileName: "見積書.pdf",
+      });
+    });
+
+    it("should throw error when the file does not exist", async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const params = parseInput({ filePath: "/tmp/uploads/missing.pdf" });
+      const mockClient = createClientWithUpload();
+
+      await expect(
+        uploadFile.callback(params, {
+          client: mockClient,
+          attachmentsDir: undefined,
+        }),
+      ).rejects.toThrow("File not found: /tmp/uploads/missing.pdf");
+      expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when filePath points to a directory", async () => {
+      vi.mocked(fs.statSync).mockReturnValue({
+        isFile: () => false,
+      } as NodeFs.Stats);
+
+      const params = parseInput({ filePath: "/tmp/uploads" });
+      const mockClient = createClientWithUpload();
+
+      await expect(
+        uploadFile.callback(params, {
+          client: mockClient,
+          attachmentsDir: undefined,
+        }),
+      ).rejects.toThrow(
+        "filePath must point to a file, but it points to a directory: /tmp/uploads",
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when fileName contains a path separator", async () => {
+      const params = parseInput({
+        filePath: "/tmp/uploads/report.pdf",
+        fileName: "sub/report.pdf",
+      });
+      const mockClient = createClientWithUpload();
+
+      await expect(
+        uploadFile.callback(params, {
+          client: mockClient,
+          attachmentsDir: undefined,
+        }),
+      ).rejects.toThrow(
+        "fileName must not contain a path separator: sub/report.pdf",
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when the upload fails", async () => {
+      mockUploadFile.mockRejectedValueOnce(new Error("Upload failed"));
+
+      const params = parseInput({ filePath: "/tmp/uploads/report.pdf" });
+      const mockClient = createClientWithUpload();
+
+      await expect(
+        uploadFile.callback(params, {
+          client: mockClient,
+          attachmentsDir: undefined,
+        }),
+      ).rejects.toThrow("Upload failed");
+    });
+  });
+});

--- a/src/tools/kintone/file/upload-file.ts
+++ b/src/tools/kintone/file/upload-file.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import { createTool } from "../../factory.js";
+import type { KintoneToolCallback } from "../../types/tool.js";
+
+const inputSchema = {
+  filePath: z
+    .string()
+    .min(1)
+    .describe(
+      "Path to the local file to upload. Absolute path, or a file name resolved against KINTONE_ATTACHMENTS_DIR.",
+    ),
+  fileName: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "File name to register in kintone. Defaults to the base name of filePath. Must not contain a path separator; a non-ASCII name is sent as UTF-8.",
+    ),
+};
+
+const outputSchema = {
+  fileKey: z
+    .string()
+    .describe(
+      "File key of the uploaded file in temporary storage, used as the value of an attachment field when the file is attached to a record or space",
+    ),
+  fileName: z.string().describe("File name that was registered in kintone"),
+  fileSize: z.number().describe("Size of the uploaded file in bytes"),
+};
+
+const resolveUploadFilePath = (
+  filePath: string,
+  attachmentsDir: string | undefined,
+): string => {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+  if (!attachmentsDir) {
+    throw new Error(
+      `filePath must be an absolute path unless KINTONE_ATTACHMENTS_DIR is set: ${filePath}`,
+    );
+  }
+  return path.resolve(attachmentsDir, filePath);
+};
+
+const toolName = "kintone-upload-file";
+const toolConfig = {
+  title: "Upload File to Kintone",
+  description:
+    "Upload one local file to the temporary storage of kintone via the File REST API (POST /k/v1/file.json) and return its fileKey. " +
+    "Only a single file can be uploaded per call, so repeat the call for each file. " +
+    "filePath must be an absolute path, or a file name resolved against KINTONE_ATTACHMENTS_DIR. " +
+    "The returned fileKey identifies the file in temporary storage and is what an attachment field expects when the file is attached to a record, a space, or an app setting. " +
+    "It is a different kind of key from the attachment fileKey returned by record retrieval, and such a retrieval fileKey cannot be re-uploaded or reused here. " +
+    "Uploading itself needs no specific permission; the permissions that matter are those of the operation that later attaches the file. " +
+    "A file left in temporary storage without being attached is deleted after 3 days, and files in temporary storage also count toward the disk usage of the domain.",
+  inputSchema,
+  outputSchema,
+};
+
+const callback: KintoneToolCallback<typeof inputSchema> = async (
+  { filePath, fileName },
+  { client, attachmentsDir },
+) => {
+  const resolvedPath = resolveUploadFilePath(filePath, attachmentsDir);
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`File not found: ${resolvedPath}`);
+  }
+  if (!fs.statSync(resolvedPath).isFile()) {
+    throw new Error(
+      `filePath must point to a file, but it points to a directory: ${resolvedPath}`,
+    );
+  }
+
+  const name = fileName ?? path.basename(resolvedPath);
+  if (name !== path.basename(name)) {
+    throw new Error(`fileName must not contain a path separator: ${name}`);
+  }
+
+  const data = await fs.promises.readFile(resolvedPath);
+
+  const { fileKey } = await client.file.uploadFile({
+    file: { name, data },
+  });
+
+  const result = {
+    fileKey,
+    fileName: name,
+    fileSize: data.byteLength,
+  };
+
+  return {
+    structuredContent: result,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+};
+
+export const uploadFile = createTool(toolName, toolConfig, callback);


### PR DESCRIPTION
## Why

The server could already pull attachments out of kintone with `kintone-download-file`, but there was no way to push a file back in. Attaching a file to a record, a space, or an app setting requires a `fileKey` from the File REST API, and without an upload tool that key could never be obtained—so any workflow that produced a file locally (a generated report, an edited spreadsheet, a file downloaded from another app) dead-ended at the point of attaching it.

This adds the missing half of the file round trip. The file is read from the local filesystem and streamed to kintone's temporary storage, so the file contents never pass through the conversation, and the model only handles the resulting `fileKey`.

## What

- **Add `kintone-upload-file`**: uploads one local file to kintone's temporary storage via the File REST API (`POST /k/v1/file.json`) and returns its `fileKey`, along with the registered `fileName` and the `fileSize` in bytes. Only a single file can be uploaded per call, so the tool is meant to be called repeatedly for multiple files.
  - `filePath` accepts an absolute path, or a bare file name resolved against `KINTONE_ATTACHMENTS_DIR` (the same directory `kintone-download-file` writes to, so a downloaded file can be re-uploaded by name). A relative path with no `KINTONE_ATTACHMENTS_DIR` configured is rejected with an explicit error.
  - `fileName` is optional and defaults to the base name of `filePath`. It must not contain a path separator, and a non-ASCII name is sent as UTF-8.
  - Validates before calling the API: the path must exist and must point to a file, not a directory.
  - The description spells out that the returned `fileKey` is temporary-storage-scoped and is a different kind of key from the attachment `fileKey` returned by record retrieval (a retrieval key cannot be re-uploaded here), that uploading itself needs no specific permission, and that an unattached file is deleted after 3 days while still counting toward the domain's disk usage.
- **Add `uploadFile` to the mock client** in `src/__tests__/utils.ts` so file-related tools can be tested against it.
- **Register the tool** in `src/tools/index.ts` and **update `manifest.json`, `README.md`, and `README_en.md`**.
- **Add tests** covering the tool configuration (name, title, description, input/output schemas), absolute and `KINTONE_ATTACHMENTS_DIR`-relative paths, the `fileName` override including a non-ASCII name, and each error path (missing `KINTONE_ATTACHMENTS_DIR`, file not found, directory instead of file, path separator in `fileName`, API failure).

## How to test

1. Set `KINTONE_ATTACHMENTS_DIR` to a directory containing a file, and configure `KINTONE_BASE_URL` with credentials for a test app that has an attachment field.
2. **Absolute path**: call `kintone-upload-file` with an absolute `filePath` and confirm a `fileKey` is returned and that `fileName`/`fileSize` match the file on disk.
3. **Relative path**: call it with just the file name and confirm it resolves against `KINTONE_ATTACHMENTS_DIR`. Unset `KINTONE_ATTACHMENTS_DIR` and confirm a relative path is rejected with a clear error.
4. **Round trip**: pass the returned `fileKey` as the value of an attachment field via `kintone-add-records` (or `kintone-update-records`) and confirm the file is attached and downloadable, then confirm `kintone-download-file` brings it back and that file can be uploaded again by name.
5. **Rename**: pass a `fileName` (including a non-ASCII one such as `見積書.pdf`) and confirm that is the name registered in kintone, not the base name of `filePath`.
6. **Errors**: confirm a non-existent path, a directory path, and a `fileName` containing `/` each fail before any request is sent.
7. Run `pnpm lint` and `pnpm test` at the repo root.

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.